### PR TITLE
Only change opts.ssl_ca_cert to "*" if secure connection is enabled

### DIFF
--- a/src/MongooseMqttClient.cpp
+++ b/src/MongooseMqttClient.cpp
@@ -130,7 +130,7 @@ bool MongooseMqttClient::connect(MongooseMqttProtocol protocol, const char *serv
 
     Mongoose.getDefaultOpts(&opts, secure);
 #if MG_ENABLE_SSL
-    if(!_reject_unauthorized) {
+    if(!_reject_unauthorized && secure) {
       opts.ssl_ca_cert = "*";
     }
 #endif


### PR DESCRIPTION
Hi there, 

because mg_connect_opt tries to establish a TLS encrypted session if opts.ssl_ca_cert != NULL it is not valid to set opts.ssl_ca_cert to "*" if there is an unencrypted MQTT session. 

