### PR TITLE
definition of min conflicts with ESP32 std::deque implementation

### DIFF
--- a/src/MongooseHttp.h
+++ b/src/MongooseHttp.h
@@ -23,10 +23,6 @@
 #define ARDUINO_MONGOOSE_SEND_BUFFER_SIZE 256
 #endif
 
-#ifndef min
-#define min(a, b) (((a) < (b)) ? (a) : (b))
-#endif
-
 typedef enum {
   HTTP_GET     = 0b00000001,
   HTTP_POST    = 0b00000010,

--- a/src/MongooseHttpServer.cpp
+++ b/src/MongooseHttpServer.cpp
@@ -714,7 +714,7 @@ void MongooseHttpServerResponseBasic::setContent(const uint8_t *content, size_t 
 
 size_t MongooseHttpServerResponseBasic::sendBody(struct mg_connection *nc, size_t bytes)
 {
-  size_t send = min(len, bytes);
+  size_t send = std::min(len, bytes);
 
   mg_send(nc, ptr, send);
 
@@ -753,7 +753,7 @@ size_t MongooseHttpServerResponseStream::write(uint8_t data)
 
 size_t MongooseHttpServerResponseStream::sendBody(struct mg_connection *nc, size_t bytes)
 {
-  size_t send = min(_content.len, bytes);
+  size_t send = std::min(_content.len, bytes);
 
   mg_send(nc, _content.buf, send);
 


### PR DESCRIPTION
Hi, when I compile the newest version of my OCPP library with ArduinoMongoose, I get the following compiler error:

```
In file included from .pio/libdeps/openevse_wifi_v1/ArduinoMongoose/src/MongooseHttpClient.h:13:0,
                 from src/ocpp.h:16,
                 from src/ocpp.cpp:6:
~\.platformio\packages\toolchain-xtensa32\xtensa-esp32-elf\include\c++\5.2.0\bits\deque.tcc: In function 
'std::_Deque_iterator<_Tp, _Tp&, _Tp*> std::copy(std::_Deque_iterator<_Tp, const _Tp&, const _Tp*>, std::_Deque_iterator<_Tp, const _Tp&, const _Tp*>, std::_Deque_iterator<_Tp, _Tp&, _Tp*>)':
.pio/libdeps/openevse_wifi_v1/ArduinoMongoose/src/MongooseHttp.h:27:19: error: expected unqualified-id before '(' token
 #define min(a, b) (((a) < (b)) ? (a) : (b))
                   ^
.pio/libdeps/openevse_wifi_v1/ArduinoMongoose/src/MongooseHttp.h:27:19: error: expected unqualified-id before '(' token
 #define min(a, b) (((a) < (b)) ? (a) : (b))
                   ^
.pio/libdeps/openevse_wifi_v1/ArduinoMongoose/src/MongooseHttp.h:27:19: error: expected unqualified-id before '(' token
 #define min(a, b) (((a) < (b)) ? (a) : (b))
                   ^
[...]
```
I assume that this is due to a defect in the ESP32 toolchain. However, as it is sufficient to remove the `min` definition in `MongooseHttp.h`, maybe we can do that as a workaround? On my machine, `min` resolves to `std::min` then and I didn't observe any side-effect. But maybe you should double-check it.