### PR TITLE
don't send a body on ::send(int code) where body is illegal

### DIFF
--- a/src/MongooseHttpServer.cpp
+++ b/src/MongooseHttpServer.cpp
@@ -429,9 +429,22 @@ void MongooseHttpServerRequest::sendBody()
 
 extern "C" const char *mg_status_message(int status_code);
 
+bool MongooseHttpServerRequest::bodyAllowed(int code)
+{
+  if(code >= 100 && code < 200) {
+    return false;
+  }
+  return !(code == 204 || code == 304);
+}
+
 void MongooseHttpServerRequest::send(int code)
 {
-  send(code, "text/plain", mg_status_message(code));
+  if (bodyAllowed(code)) {
+    send(code, "text/plain", mg_status_message(code));
+  } else {
+    send(code, "text/plain", "");
+  }
+
 }
 
 void MongooseHttpServerRequest::send(int code, const char *contentType, const char *content)

--- a/src/MongooseHttpServer.h
+++ b/src/MongooseHttpServer.h
@@ -50,6 +50,7 @@ class MongooseHttpServerRequest {
     bool _responseSent;
 
     void sendBody();
+    bool bodyAllowed(int code);
 
 #if MG_COPY_HTTP_MESSAGE
     http_message *duplicateMessage(http_message *);


### PR DESCRIPTION
I'm running this fork locally and it seems to have finally resolved the issue with the Safari 304 issue