### PR TITLE
improve HTTP client connection lifecycle and TLS cleanup

### DIFF
--- a/src/MongooseHttpClient.cpp
+++ b/src/MongooseHttpClient.cpp
@@ -88,6 +88,7 @@ void MongooseHttpClient::eventHandler(struct mg_connection *nc, MongooseHttpClie
 
     case MG_EV_CLOSE: {
       DBUGF("Connection %p closed", nc);
+      request->_nc = NULL;
       if(request->_onClose) {
         request->_onClose();
       }
@@ -130,19 +131,39 @@ MongooseHttpClientRequest *MongooseHttpClient::beginRequest(const char *uri)
   return new MongooseHttpClientRequest(this, uri);
 }
 
-void MongooseHttpClient::send(MongooseHttpClientRequest *request)
+bool MongooseHttpClient::send(MongooseHttpClientRequest *request)
 {
+  if(NULL == request) {
+    return false;
+  }
+
+  // The wrapper does not pool or reuse HTTP connections.
+  if(!request->addHeader("Connection", "close")) {
+    DBUGLN("Failed to add Connection: close header");
+    if(request->_onClose) {
+      request->_onClose();
+    }
+    delete request;
+    return false;
+  }
+
   struct mg_connect_opts opts;
   Mongoose.getDefaultOpts(&opts);
 
-  const char *err;
+  const char *err = "unknown error";
   opts.error_string = &err;
 
   mg_connection *nc = mg_connect_http_opt(Mongoose.getMgr(), eventHandler, request, opts, request->_uri, request->_extraHeaders, (const char *)request->_body);
   if(nc) {
     request->_nc = nc;
+    return true;
   } else {
     DBUGF("Failed to connect to %s: %s", request->_uri, err);
+    if(request->_onClose) {
+      request->_onClose();
+    }
+    delete request;
+    return false;
   }
 }
 
@@ -156,7 +177,8 @@ MongooseHttpClientRequest::MongooseHttpClientRequest(MongooseHttpClient *client,
   _contentType("application/x-www-form-urlencoded"),
   _contentLength(-1),
   _body(NULL),
-  _extraHeaders(NULL)
+  _extraHeaders(NULL),
+  _nc(NULL)
 {
 
 }

--- a/src/MongooseHttpClient.cpp
+++ b/src/MongooseHttpClient.cpp
@@ -131,20 +131,11 @@ MongooseHttpClientRequest *MongooseHttpClient::beginRequest(const char *uri)
   return new MongooseHttpClientRequest(this, uri);
 }
 
-bool MongooseHttpClient::send(MongooseHttpClientRequest *request)
+void MongooseHttpClient::send(MongooseHttpClientRequest *request)
 {
-  if(NULL == request) {
-    return false;
-  }
-
   // The wrapper does not pool or reuse HTTP connections.
   if(!request->addHeader("Connection", "close")) {
     DBUGLN("Failed to add Connection: close header");
-    if(request->_onClose) {
-      request->_onClose();
-    }
-    delete request;
-    return false;
   }
 
   struct mg_connect_opts opts;
@@ -156,14 +147,8 @@ bool MongooseHttpClient::send(MongooseHttpClientRequest *request)
   mg_connection *nc = mg_connect_http_opt(Mongoose.getMgr(), eventHandler, request, opts, request->_uri, request->_extraHeaders, (const char *)request->_body);
   if(nc) {
     request->_nc = nc;
-    return true;
   } else {
     DBUGF("Failed to connect to %s: %s", request->_uri, err);
-    if(request->_onClose) {
-      request->_onClose();
-    }
-    delete request;
-    return false;
   }
 }
 

--- a/src/MongooseHttpClient.h
+++ b/src/MongooseHttpClient.h
@@ -175,7 +175,8 @@ class MongooseHttpClient
     ~MongooseHttpClient();
 
     MongooseHttpClientRequest *beginRequest(const char *uri);
-    void send(MongooseHttpClientRequest *request);
+    // A false return means onClose has run and the request has been deleted.
+    bool send(MongooseHttpClientRequest *request);
 
     void get(const char* uri, MongooseHttpResponseHandler onResponse = NULL, MongooseHttpCloseHandler onClose = NULL);
     void post(const char* uri, const char *contentType, const char *body, MongooseHttpResponseHandler onResponse = NULL, MongooseHttpCloseHandler onClose = NULL);

--- a/src/MongooseHttpClient.h
+++ b/src/MongooseHttpClient.h
@@ -175,7 +175,8 @@ class MongooseHttpClient
     ~MongooseHttpClient();
 
     MongooseHttpClientRequest *beginRequest(const char *uri);
-    // A false return means onClose has run and the request has been deleted.
+    // Returns true if the request was queued successfully. On false, the request
+    // (if non-null) has been deleted and onClose was invoked if set.
     bool send(MongooseHttpClientRequest *request);
 
     void get(const char* uri, MongooseHttpResponseHandler onResponse = NULL, MongooseHttpCloseHandler onClose = NULL);

--- a/src/MongooseHttpClient.h
+++ b/src/MongooseHttpClient.h
@@ -175,9 +175,7 @@ class MongooseHttpClient
     ~MongooseHttpClient();
 
     MongooseHttpClientRequest *beginRequest(const char *uri);
-    // Returns true if the request was queued successfully. On false, the request
-    // (if non-null) has been deleted and onClose was invoked if set.
-    bool send(MongooseHttpClientRequest *request);
+    void send(MongooseHttpClientRequest *request);
 
     void get(const char* uri, MongooseHttpResponseHandler onResponse = NULL, MongooseHttpCloseHandler onClose = NULL);
     void post(const char* uri, const char *contentType, const char *body, MongooseHttpResponseHandler onResponse = NULL, MongooseHttpCloseHandler onClose = NULL);

--- a/src/mongoose.c
+++ b/src/mongoose.c
@@ -5415,11 +5415,11 @@ void mg_ssl_if_conn_free(struct mg_connection *nc) {
     mbedtls_ssl_free(ctx->ssl);
     MG_FREE(ctx->ssl);
   }
+  mg_ssl_if_mbed_free_certs_and_keys(ctx);
   if (ctx->conf != NULL) {
     mbedtls_ssl_config_free(ctx->conf);
     MG_FREE(ctx->conf);
   }
-  mg_ssl_if_mbed_free_certs_and_keys(ctx);
   mbuf_free(&ctx->cipher_suites);
   memset(ctx, 0, sizeof(*ctx));
   MG_FREE(ctx);


### PR DESCRIPTION
While trying to fix the HTTP ota issue, I went to this false path, won't hurt to keep it.

- force Connection: close for non-pooled HTTP requests
- return send status and clean up synchronous failures
- initialize and clear the request connection pointer
- free mbedTLS certificates before the SSL configuration