### PR TITLE
feat(http): HTTP keep-alive support for MongooseHttpServer

### DIFF
--- a/src/MongooseHttpServer.cpp
+++ b/src/MongooseHttpServer.cpp
@@ -16,9 +16,27 @@
 
 MongooseHttpServer::MongooseHttpServer() :
   nc(NULL),
-  defaultEndpoint(this, HTTP_ANY)
+  defaultEndpoint(this, HTTP_ANY),
+  _keepAliveEnabled(true)
 {
 
+}
+
+bool MongooseHttpServer::allowKeepAlive()
+{
+  if(!_keepAliveEnabled) {
+    return false;
+  }
+
+  // Count every connection on the manager, not just ours: HTTP clients, MQTT,
+  // etc all share the same (small) network stack pool.
+  int connections = 0;
+  mg_mgr *mgr = Mongoose.getMgr();
+  for(mg_connection *c = mg_next(mgr, NULL); c != NULL; c = mg_next(mgr, c)) {
+    connections++;
+  }
+
+  return connections <= ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS;
 }
 
 MongooseHttpServer::~MongooseHttpServer()
@@ -112,6 +130,22 @@ void MongooseHttpServer::endpointEventHandler(struct mg_connection *nc, int ev, 
   self->server->eventHandler(nc, ev, p, self->method, self);
 }
 
+// Free a keep-alive request whose response has fully completed, leaving the
+// connection open for the next request. Close-mode requests stay attached
+// until MG_EV_CLOSE so their endpoint close callback keeps firing.
+static void checkRequestDone(struct mg_connection *nc)
+{
+  if(nc->user_connection_data)
+  {
+    MongooseHttpServerRequest *request = (MongooseHttpServerRequest *)nc->user_connection_data;
+    if(request->keepAlive() && request->completed() && !request->responseSent()) {
+      DBUGF("Connection %p: request complete, keeping alive", nc);
+      delete request;
+      nc->user_connection_data = NULL;
+    }
+  }
+}
+
 void MongooseHttpServer::eventHandler(struct mg_connection *nc, int ev, void *p, HttpRequestMethodComposite method, MongooseHttpServerEndpoint *endpoint)
 {
   if (ev != MG_EV_POLL) { DBUGF("%s %p: %d", __PRETTY_FUNCTION__, nc, ev); }
@@ -138,11 +172,14 @@ void MongooseHttpServer::eventHandler(struct mg_connection *nc, int ev, void *p,
       DBUGF("HTTP request from %s: %.*s %.*s", addr, (int) hm->method.len,
              hm->method.p, (int) hm->uri.len, hm->uri.p);
 
+      // A new request on this connection: cancel any pending keep-alive idle
+      // timer and free the previous request (normally already cleaned up).
+      mg_set_timer(nc, 0);
       if(nc->user_connection_data) {
         delete (MongooseHttpServerRequest *)nc->user_connection_data;
         nc->user_connection_data = NULL;
       }
-      MongooseHttpServerRequest *request = 
+      MongooseHttpServerRequest *request =
 #if MG_ENABLE_HTTP_STREAMING_MULTIPART
         MG_EV_HTTP_MULTIPART_REQUEST == ev ? new MongooseHttpServerRequestUpload(this, nc, hm) :
 #endif
@@ -154,7 +191,7 @@ void MongooseHttpServer::eventHandler(struct mg_connection *nc, int ev, void *p,
       {
         nc->user_connection_data = request;
 
-        if(endpoint->request) 
+        if(endpoint->request)
         {
           endpoint->request(request);
 #if MG_ENABLE_HTTP_WEBSOCKET
@@ -164,6 +201,11 @@ void MongooseHttpServer::eventHandler(struct mg_connection *nc, int ev, void *p,
         } else {
           mg_http_send_error(nc, 404, NULL);
         }
+
+        // Keep-alive: a request whose response completed synchronously is
+        // finished with — free it so the connection can host the next one.
+        // (Close-mode requests are freed on MG_EV_CLOSE as before.)
+        checkRequestDone(nc);
       } else {
         mg_http_send_error(nc, 500, NULL);
       }
@@ -201,8 +243,20 @@ void MongooseHttpServer::eventHandler(struct mg_connection *nc, int ev, void *p,
         if(request->responseSent()) {
           request->sendBody();
         }
+        checkRequestDone(nc);
       }
 
+      break;
+    }
+
+    case MG_EV_TIMER:
+    {
+      // Idle keep-alive connection outlived its welcome — close it. A live
+      // request in flight means the timer is stale; ignore it.
+      if(NULL == nc->user_connection_data) {
+        DBUGF("Connection %p: keep-alive idle timeout", nc);
+        nc->flags |= MG_F_SEND_AND_CLOSE;
+      }
       break;
     }
 
@@ -293,8 +347,24 @@ MongooseHttpServerRequest::MongooseHttpServerRequest(MongooseHttpServer *server,
   _msg(msg),
 #endif
   _response(NULL),
-  _responseSent(false)
+  _responseSent(false),
+  _keepAlive(false),
+  _completed(false)
 {
+  // HTTP/1.1 defaults to keep-alive, HTTP/1.0 to close; an explicit
+  // Connection header from the client wins either way. The server can still
+  // veto (pool pressure, runtime switch) via allowKeepAlive().
+  bool clientKeepAlive = (0 == mg_vcmp(&msg->proto, "HTTP/1.1"));
+  mg_str *connection = mg_get_http_header(msg, "Connection");
+  if(connection) {
+    if(0 == mg_vcasecmp(connection, "close")) {
+      clientKeepAlive = false;
+    } else if(0 == mg_vcasecmp(connection, "keep-alive")) {
+      clientKeepAlive = true;
+    }
+  }
+  _keepAlive = clientKeepAlive && server->allowKeepAlive();
+
   if(0 == mg_vcasecmp(&msg->method, "GET")) {
     _method = HTTP_GET;
   } else if(0 == mg_vcasecmp(&msg->method, "POST")) {
@@ -392,6 +462,18 @@ MongooseHttpServerResponseStream *MongooseHttpServerRequest::beginResponseStream
 
 #endif
 
+void MongooseHttpServerRequest::completeRequest()
+{
+  _completed = true;
+  if(_keepAlive) {
+    // Leave the connection open for the next request, but reap it if the
+    // client parks it idle for too long.
+    mg_set_timer(_nc, mg_time() + ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT);
+  } else {
+    _nc->flags |= MG_F_SEND_AND_CLOSE;
+  }
+}
+
 void MongooseHttpServerRequest::send(MongooseHttpServerResponse *response)
 {
   if(_response) {
@@ -399,6 +481,7 @@ void MongooseHttpServerRequest::send(MongooseHttpServerResponse *response)
     _response = NULL;
   }
 
+  response->setKeepAlive(_keepAlive);
   response->sendHeaders(_nc);
   _response = response;
   sendBody();
@@ -422,6 +505,7 @@ void MongooseHttpServerRequest::sendBody()
         DBUGLN("Response finished");
         delete _response;
         _response = NULL;
+        completeRequest();
       }
     }
   }
@@ -450,14 +534,15 @@ void MongooseHttpServerRequest::send(int code)
 void MongooseHttpServerRequest::send(int code, const char *contentType, const char *content)
 {
   char headers[64], *pheaders = headers;
-  mg_asprintf(&pheaders, sizeof(headers), 
-      "Connection: close\r\n"
+  mg_asprintf(&pheaders, sizeof(headers),
+      "Connection: %s\r\n"
       "Content-Type: %s",
+      _keepAlive ? "keep-alive" : "close",
       contentType);
 
   mg_send_head(_nc, code, strlen(content), pheaders);
   mg_send(_nc, content, strlen(content));
-  _nc->flags |= MG_F_SEND_AND_CLOSE;
+  completeRequest();
 
   if (pheaders != headers) free(pheaders);
 
@@ -605,13 +690,15 @@ void MongooseHttpServerRequest::requestAuthentication(const char* realm)
   // https://github.com/me-no-dev/ESPAsyncWebServer/blob/master/src/WebRequest.cpp#L852
   // mg_http_send_digest_auth_request
 
-  char headers[64], *pheaders = headers;
-  mg_asprintf(&pheaders, sizeof(headers), 
+  char headers[96], *pheaders = headers;
+  mg_asprintf(&pheaders, sizeof(headers),
+      "Connection: %s\r\n"
       "WWW-Authenticate: Basic realm=%s",
+      _keepAlive ? "keep-alive" : "close",
       realm);
 
   mg_send_head(_nc, 401, 0, pheaders);
-  _nc->flags |= MG_F_SEND_AND_CLOSE;
+  completeRequest();
 
   if (pheaders != headers) free(pheaders);
 
@@ -622,7 +709,8 @@ MongooseHttpServerResponse::MongooseHttpServerResponse() :
   _code(200),
   _contentType(NULL),
   _contentLength(-1),
-  _headerBuffer(NULL)
+  _headerBuffer(NULL),
+  _keepAlive(false)
 {
 
 }
@@ -642,9 +730,10 @@ MongooseHttpServerResponse::~MongooseHttpServerResponse()
 void MongooseHttpServerResponse::sendHeaders(struct mg_connection *nc)
 {
   char headers[64], *pheaders = headers;
-  mg_asprintf(&pheaders, sizeof(headers), 
-      "Connection: close\r\n"
+  mg_asprintf(&pheaders, sizeof(headers),
+      "Connection: %s\r\n"
       "Content-Type: %s%s",
+      _keepAlive ? "keep-alive" : "close",
       _contentType ? _contentType : "text/plain", _headerBuffer ? _headerBuffer : "");
 
   mg_send_head(nc, _code, _contentLength, pheaders);
@@ -735,7 +824,7 @@ size_t MongooseHttpServerResponseBasic::sendBody(struct mg_connection *nc, size_
   ptr += send;
   len -= send;
 
-  if(0 == len) {
+  if(0 == len && !_keepAlive) {
     nc->flags |= MG_F_SEND_AND_CLOSE;
   }
 
@@ -773,7 +862,7 @@ size_t MongooseHttpServerResponseStream::sendBody(struct mg_connection *nc, size
 
   mbuf_remove(&_content, send);
 
-  if(0 == _content.len) {
+  if(0 == _content.len && !_keepAlive) {
     nc->flags |= MG_F_SEND_AND_CLOSE;
   }
 
@@ -786,6 +875,9 @@ size_t MongooseHttpServerResponseStream::sendBody(struct mg_connection *nc, size
 MongooseHttpWebSocketConnection::MongooseHttpWebSocketConnection(MongooseHttpServer *server, mg_connection *nc, http_message *msg) :
   MongooseHttpServerRequest(server, nc, msg)
 {
+  // WebSocket connections manage their own lifetime; the HTTP keep-alive
+  // machinery (completion cleanup, idle reaper) must leave them alone.
+  _keepAlive = false;
   nc->flags |= MG_F_IS_MongooseHttpWebSocketConnection;
 }
 

--- a/src/MongooseHttpServer.h
+++ b/src/MongooseHttpServer.h
@@ -25,6 +25,20 @@
 #define MG_COPY_HTTP_MESSAGE 1
 #endif
 
+// HTTP keep-alive. Connections are reused for further requests when the
+// client supports it, instead of being closed after every response. An idle
+// kept-alive connection is closed after ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT
+// seconds. Keep-alive is not offered while the manager already has more than
+// ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS connections — embedded TCP/IP
+// stacks have small connection pools (LWIP defaults to 16 on ESP32) and
+// parked connections would starve them.
+#ifndef ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT
+#define ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT 30
+#endif
+#ifndef ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS
+#define ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS 8
+#endif
+
 class MongooseHttpServer;
 class MongooseHttpServerRequest;
 class MongooseHttpServerResponse;
@@ -48,9 +62,14 @@ class MongooseHttpServerRequest {
     HttpRequestMethodComposite _method;
     MongooseHttpServerResponse *_response;
     bool _responseSent;
+    bool _keepAlive;
+    bool _completed;
 
     void sendBody();
     bool bodyAllowed(int code);
+    // Mark the response finished: close the connection (legacy mode) or arm
+    // the idle timer and leave it open for the next request (keep-alive).
+    void completeRequest();
 
 #if MG_COPY_HTTP_MESSAGE
     http_message *duplicateMessage(http_message *);
@@ -62,6 +81,20 @@ class MongooseHttpServerRequest {
 
     virtual bool isUpload() { return false; }
     virtual bool isWebSocket() { return false; }
+
+    // True when the connection will be kept open for further requests after
+    // this response completes.
+    bool keepAlive() const {
+      return _keepAlive;
+    }
+    // Close the connection after this response even if the client asked for
+    // keep-alive. Call before sending the response.
+    void forceClose() {
+      _keepAlive = false;
+    }
+    bool completed() const {
+      return _completed;
+    }
 
     HttpRequestMethodComposite method() {
       return _method;
@@ -191,6 +224,9 @@ class MongooseHttpServerRequestUpload : public MongooseHttpServerRequest
       MongooseHttpServerRequest(server, nc, msg),
       index(0)
     {
+      // Multipart uploads keep the close-per-request lifecycle: consumers use
+      // the connection-close event to finalise the upload.
+      _keepAlive = false;
     }
     virtual ~MongooseHttpServerRequestUpload() {
     }
@@ -207,6 +243,9 @@ class MongooseHttpServerResponse
 
     char * _headerBuffer;
 
+  protected:
+    bool _keepAlive;
+
   public:
     MongooseHttpServerResponse();
     virtual ~MongooseHttpServerResponse();
@@ -217,6 +256,9 @@ class MongooseHttpServerResponse
     void setContentType(const char *contentType);
     void setContentLength(int64_t contentLength) {
       _contentLength = contentLength;
+    }
+    void setKeepAlive(bool keepAlive) {
+      _keepAlive = keepAlive;
     }
 
     bool addHeader(const char *name, const char *value);
@@ -373,6 +415,7 @@ class MongooseHttpServer
   protected:
     struct mg_connection *nc;
     MongooseHttpServerEndpoint defaultEndpoint;
+    bool _keepAliveEnabled;
 
     static void defaultEventHandler(struct mg_connection *nc, int ev, void *p, void *u);
     static void endpointEventHandler(struct mg_connection *nc, int ev, void *p, void *u);
@@ -396,6 +439,14 @@ class MongooseHttpServer
     void onNotFound(MongooseHttpRequestHandler fn);
 
     void reset();
+
+    // Runtime switch for HTTP keep-alive (on by default).
+    void enableKeepAlive(bool enable) {
+      _keepAliveEnabled = enable;
+    }
+    // Whether a new request may hold its connection open: keep-alive enabled
+    // and the connection pool not under pressure.
+    bool allowKeepAlive();
 
 #if MG_ENABLE_HTTP_WEBSOCKET
     void sendAll(MongooseHttpWebSocketConnection *from, const char *endpoint, int op, const void *data, size_t len);


### PR DESCRIPTION
The server currently closes every connection after a single response — `Connection: close` plus `MG_F_SEND_AND_CLOSE` on all paths. On embedded targets each request from a polling client (Home Assistant, a dashboard tab, a scripted poller) burns a fresh TCP PCB, and LWIP's default pool on ESP32 is only 16. I traced a reproducible failure on an OpenEVSE unit where an in-flight OTA transfer was reset at a random offset every time: once the pool is exhausted by connection churn plus a few parallel requests, LWIP frees a PCB by force and the long-lived transfer is the casualty.

This adds HTTP keep-alive to `MongooseHttpServer` (the underlying mongoose HTTP state machine already handles multiple requests per connection — the wrapper was closing them):

- **Per-request negotiation.** HTTP/1.1 defaults to keep-alive, HTTP/1.0 to close, and an explicit `Connection` header from the client wins either way. Responses advertise the negotiated behaviour.
- **Pool-pressure veto.** Keep-alive is refused (`Connection: close`, exactly the old behaviour) while the manager already has more than `ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS` (default 8) connections, so parked connections can never starve the stack's pool. `server.enableKeepAlive(false)` restores the previous close-per-request behaviour entirely.
- **Idle reaping.** A kept-alive connection with no request in flight is closed after `ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT` (default 30 s) via `mg_set_timer`/`MG_EV_TIMER`.
- **Lifecycle.** A completed keep-alive request is freed as soon as its response has been fully queued, leaving the connection ready for the next request. Close-mode requests keep the existing lifecycle unchanged: freed on `MG_EV_CLOSE`, endpoint `onClose` callbacks fire as before. Multipart uploads and WebSocket connections are exempt and keep their close-based flows, and `request->forceClose()` lets an application opt any individual request out before responding.

Both defaults are compile-time overridable. No API breakage: existing applications compile unchanged, and OpenEVSE's firmware needed zero source changes (its OTA upload path relies on close-on-completion and is exempt by class).

Hardware-tested on an OpenEVSE ESP32-WROOM build of this branch:

- curl reuses a single connection across sequential requests (`Connection: keep-alive`, connection left intact)
- an idle kept-alive connection is closed by the server after 30.0 s
- with 10 connections held open, new requests get `Connection: close` (veto working)
- a 2.5 MB multipart OTA upload completes with a keep-alive client polling `/status` twice a second throughout — the scenario that previously reset the transfer within the first few hundred KB
- WebSockets (`/ws`, debug console) and the web UI behave unchanged
