### PR TITLE
feat(http): HTTP keep-alive for MongooseHttpServer on the Mongoose 7 stack

### DIFF
--- a/src/MongooseHttpServer.cpp
+++ b/src/MongooseHttpServer.cpp
@@ -15,7 +15,9 @@
 MongooseHttpServer::MongooseHttpServer() :
   MongooseHttpServerConnection(),
   _endpoints(),
-  _notFound(HTTP_ANY, "#")
+  _notFound(HTTP_ANY, "#"),
+  _keepAliveEnabled(true),
+  _keepAliveTimeoutMs(ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT * 1000)
 {
   _notFound.onRequest([](MongooseHttpServerRequest *request) {
     request->send(404);
@@ -25,6 +27,23 @@ MongooseHttpServer::MongooseHttpServer() :
 MongooseHttpServer::~MongooseHttpServer()
 {
 
+}
+
+bool MongooseHttpServer::allowKeepAlive()
+{
+  if(!_keepAliveEnabled) {
+    return false;
+  }
+
+  // Count every connection on the manager, not just this server's: HTTP
+  // clients, MQTT, etc all share the same (small) network stack pool.
+  int connections = 0;
+  mg_mgr *mgr = Mongoose.getMgr();
+  for(mg_connection *c = mgr->conns; c != nullptr; c = c->next) {
+    connections++;
+  }
+
+  return connections <= ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS;
 }
 
 bool MongooseHttpServer::begin(uint16_t port)
@@ -151,7 +170,7 @@ void MongooseHttpServer::handleHeaders(mg_connection *nc, mg_http_message *msg)
 
   for(auto &handler : _endpoints)
   {
-    RequestHandle endpointHandled = handler->willHandleRequest(nc, requestMethod, msg);
+    RequestHandle endpointHandled = handler->willHandleRequest(this, nc, requestMethod, msg);
     switch (endpointHandled)
     {
       case REQUEST_WILL_HANDLE:
@@ -176,7 +195,7 @@ void MongooseHttpServer::handleHeaders(mg_connection *nc, mg_http_message *msg)
     mg_http_reply(nc, 405, nullptr, "Method Not Allowed");
     nc->is_draining = 1;
   } else if(handled == REQUEST_NO_MATCH) {
-    _notFound.willHandleRequest(nc, requestMethod, msg);
+    _notFound.willHandleRequest(this, nc, requestMethod, msg);
   }
 }
 

--- a/src/MongooseHttpServer.h
+++ b/src/MongooseHttpServer.h
@@ -47,6 +47,15 @@ class MongooseHttpServer : public MongooseHttpServerConnection
 
     HttpRequestMethodComposite method(mg_str method);
   protected:
+    /**
+     * @brief Match request headers to an endpoint and create the request object
+     *
+     * Called for the first request on a connection and again by a completed
+     * keep-alive request when its connection receives the next request.
+     *
+     * @param nc the Mongoose connection the request arrived on
+     * @param msg the request's parsed headers
+     */
     void handleHeaders(mg_connection *nc, mg_http_message *msg);
 
   public:

--- a/src/MongooseHttpServer.h
+++ b/src/MongooseHttpServer.h
@@ -14,6 +14,20 @@
 #include "MongooseHttpServerEndpointUpload.h"
 #include "MongooseHttpServerEndpointWebSocket.h"
 
+// HTTP keep-alive. Rather than closing after every response, a connection is
+// kept open and reused for the next request when the client supports it. An
+// idle kept-alive connection is closed after ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT
+// seconds. Keep-alive is not offered while the manager already holds more than
+// ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS connections: embedded TCP/IP
+// stacks have small connection pools (LWIP defaults to 16 on ESP32) and parked
+// connections would otherwise starve them.
+#ifndef ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT
+#define ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT 30
+#endif
+#ifndef ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS
+#define ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS 8
+#endif
+
 
  /**
   * @brief HTTP and WebSocket Server
@@ -22,10 +36,14 @@
   */ 
 class MongooseHttpServer : public MongooseHttpServerConnection
 {
+  friend class MongooseHttpServerRequest;
 
   private:
     std::list<MongooseHttpServerEndpoint *> _endpoints;
     MongooseHttpServerEndpoint _notFound;
+
+    bool _keepAliveEnabled;
+    uint32_t _keepAliveTimeoutMs;
 
     HttpRequestMethodComposite method(mg_str method);
   protected:
@@ -41,6 +59,59 @@ class MongooseHttpServer : public MongooseHttpServerConnection
      * @brief Destroy the HTTP Server object and clean up endpoints
      */
     ~MongooseHttpServer();
+
+    /**
+     * @brief Enable or disable HTTP keep-alive at runtime
+     *
+     * Enabled by default. When disabled the server closes every connection
+     * after a single response.
+     *
+     * @param enable true to allow connection reuse, false to close after each response
+     */
+    void enableKeepAlive(bool enable) {
+      _keepAliveEnabled = enable;
+    }
+
+    /**
+     * @brief Check if HTTP keep-alive is enabled
+     *
+     * @return true if new requests may negotiate keep-alive
+     * @return false if every connection closes after a single response
+     */
+    bool keepAliveEnabled() const {
+      return _keepAliveEnabled;
+    }
+
+    /**
+     * @brief Set the idle timeout for parked keep-alive connections
+     *
+     * @param timeoutMs idle time, in milliseconds, before a kept-alive connection
+     *                  is reaped. Defaults to ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT seconds.
+     */
+    void setKeepAliveTimeout(uint32_t timeoutMs) {
+      _keepAliveTimeoutMs = timeoutMs;
+    }
+
+    /**
+     * @brief Get the idle timeout for parked keep-alive connections
+     *
+     * @return uint32_t idle timeout in milliseconds
+     */
+    uint32_t keepAliveTimeout() const {
+      return _keepAliveTimeoutMs;
+    }
+
+    /**
+     * @brief Check whether a new request may be kept alive
+     *
+     * Refused while keep-alive is disabled or while the manager is already
+     * holding ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS or more connections,
+     * so connection reuse never starves the pool.
+     *
+     * @return true if the request may be kept alive
+     * @return false if the connection should close after the response
+     */
+    bool allowKeepAlive();
 
     /**
      * @brief Start the HTTP server on the specified port

--- a/src/MongooseHttpServerEndpoint.cpp
+++ b/src/MongooseHttpServerEndpoint.cpp
@@ -11,7 +11,7 @@
 #include "MongooseHttpServerEndpoint.h"
 #include "MongooseHttp.h"
 
-RequestHandle MongooseHttpServerEndpoint::willHandleRequest(mg_connection *nc, HttpRequestMethodComposite requestMethod, mg_http_message *msg)
+RequestHandle MongooseHttpServerEndpoint::willHandleRequest(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite requestMethod, mg_http_message *msg)
 {
   DBUGF("Checking if %x %.*s matches %x %.*s", requestMethod, (int)msg->uri.len, msg->uri.buf, _method, (int)_uri.length(), _uri.c_str());
 
@@ -21,7 +21,7 @@ RequestHandle MongooseHttpServerEndpoint::willHandleRequest(mg_connection *nc, H
     // Check if the method is allowed
     if(_method & requestMethod)
     {
-      MongooseHttpServerRequest *request = requestFactory(nc, requestMethod, msg);
+      MongooseHttpServerRequest *request = requestFactory(server, nc, requestMethod, msg);
       if(request)
       {
         nc->fn_data = request;

--- a/src/MongooseHttpServerEndpoint.h
+++ b/src/MongooseHttpServerEndpoint.h
@@ -39,12 +39,12 @@ class MongooseHttpServerEndpoint
     MongooseHttpRequestHandler _request;
     MongooseHttpRequestHandler _close;
 
-    RequestHandle willHandleRequest(mg_connection *nc, HttpRequestMethodComposite requestMethod, mg_http_message *msg);
+    RequestHandle willHandleRequest(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite requestMethod, mg_http_message *msg);
     void handleRequest(MongooseHttpServerRequest *request);
     void handleClose(MongooseHttpServerRequest *request);
   protected:
-    virtual MongooseHttpServerRequest *requestFactory(mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg) {
-      return new MongooseHttpServerRequest(nc, method, msg, this);
+    virtual MongooseHttpServerRequest *requestFactory(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg) {
+      return new MongooseHttpServerRequest(server, nc, method, msg, this);
     }
 
   public:

--- a/src/MongooseHttpServerEndpointUpload.h
+++ b/src/MongooseHttpServerEndpointUpload.h
@@ -22,8 +22,8 @@ class MongooseHttpServerEndpointUpload : public MongooseHttpServerEndpoint
     MongooseHttpUploadHandler _upload;
 
   protected:
-    virtual MongooseHttpServerRequest *requestFactory(mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg) {
-      return new MongooseHttpServerRequestUpload(nc, method, msg, this);
+    virtual MongooseHttpServerRequest *requestFactory(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg) {
+      return new MongooseHttpServerRequestUpload(server, nc, method, msg, this);
     }
 
   public:

--- a/src/MongooseHttpServerEndpointWebSocket.h
+++ b/src/MongooseHttpServerEndpointWebSocket.h
@@ -18,8 +18,8 @@ class MongooseHttpServerEndpointWebSocket : public MongooseHttpServerEndpoint
     MongooseHttpWebSocketFrameHandler _wsFrame;
 
   protected:
-    virtual MongooseHttpServerRequest *requestFactory(mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg) {
-      return new MongooseHttpWebSocketConnection(nc, method, msg, this);
+    virtual MongooseHttpServerRequest *requestFactory(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg) {
+      return new MongooseHttpWebSocketConnection(server, nc, method, msg, this);
     }
 
     void handleConnect(MongooseHttpWebSocketConnection *connection) {

--- a/src/MongooseHttpServerRequest.cpp
+++ b/src/MongooseHttpServerRequest.cpp
@@ -371,8 +371,13 @@ void MongooseHttpServerRequest::handlePoll(mg_connection *nc)
     return;
   }
 
-  // Reap a kept-alive connection that has been parked idle for too long.
-  if(_completed && _keepAlive &&
+  // Reap a kept-alive connection that has been parked idle for too long. A
+  // connection still flushing queued response bytes to a slow client is not
+  // idle, so the timeout only runs once the send buffer is empty. (Draining
+  // early would not truncate the response - Mongoose closes a draining
+  // connection only once the send buffer is empty - but transmit time should
+  // not count as idle time.)
+  if(_completed && _keepAlive && 0 == nc->send.len &&
      (mg_millis() - _lastActivity) >= _server->keepAliveTimeout()) {
     DBUGF("Connection %p: keep-alive idle timeout", nc);
     nc->is_draining = 1;
@@ -391,13 +396,13 @@ void MongooseHttpServerRequest::handleHeaders(mg_connection *nc, mg_http_message
 
   _server->handleHeaders(nc, msg);
 
-  // If matching did not install a new handler (404 handler aside, e.g. a 405 or
-  // 500) the connection still points at this request; detach before freeing so
-  // the pending close does not dispatch to freed memory.
-  if(nc->fn_data == this) {
-    nc->fn_data = nullptr;
+  // Retire only once a new request has taken over the connection. If matching
+  // did not install one (e.g. a 405, which drains the connection) this request
+  // stays attached so the eventual MG_EV_CLOSE still dispatches through
+  // handleClose() and the endpoint close callbacks fire as usual.
+  if(nc->fn_data != this) {
+    delete this;
   }
-  delete this;
 }
 
 void MongooseHttpServerRequest::handleMessage(mg_connection *nc, mg_http_message *msg)

--- a/src/MongooseHttpServerRequest.cpp
+++ b/src/MongooseHttpServerRequest.cpp
@@ -12,8 +12,9 @@
 
 #include "MongooseHttpServerRequest.h"
 #include "MongooseHttpServerEndpoint.h"
+#include "MongooseHttpServer.h"
 
-MongooseHttpServerRequest::MongooseHttpServerRequest(mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg, MongooseHttpServerEndpoint *endpoint) :
+MongooseHttpServerRequest::MongooseHttpServerRequest(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg, MongooseHttpServerEndpoint *endpoint) :
   MongooseHttpServerConnection(),
 #if MG_COPY_HTTP_MESSAGE
   MongooseHttpMessage(duplicateMessage(msg)),
@@ -23,10 +24,34 @@ MongooseHttpServerRequest::MongooseHttpServerRequest(mg_connection *nc, HttpRequ
   _method(method),
   _response(nullptr),
   _endpoint(endpoint),
-  _responseSent(false)
+  _responseSent(false),
+  _server(server),
+  _keepAlive(false),
+  _completed(false),
+  _lastActivity(0)
 {
   connect(nc);
   nc->fn_data = this;
+  _keepAlive = negotiateKeepAlive(msg);
+}
+
+// HTTP/1.1 defaults to keep-alive, HTTP/1.0 to close; an explicit Connection
+// header from the client wins either way. The server can still veto (pool
+// pressure or the runtime switch) through allowKeepAlive().
+bool MongooseHttpServerRequest::negotiateKeepAlive(mg_http_message *msg)
+{
+  bool clientKeepAlive = (0 == mg_strcasecmp(msg->proto, mg_str("HTTP/1.1")));
+
+  struct mg_str *connection = mg_http_get_header(msg, "Connection");
+  if(connection) {
+    if(0 == mg_strcasecmp(*connection, mg_str("close"))) {
+      clientKeepAlive = false;
+    } else if(0 == mg_strcasecmp(*connection, mg_str("keep-alive"))) {
+      clientKeepAlive = true;
+    }
+  }
+
+  return clientKeepAlive && _server->allowKeepAlive();
 }
 
 MongooseHttpServerRequest::~MongooseHttpServerRequest()
@@ -114,6 +139,7 @@ void MongooseHttpServerRequest::send(MongooseHttpServerResponse *response)
     _response = nullptr;
   }
 
+  response->setKeepAlive(_keepAlive);
   response->sendHeaders(getConnection());
   _response = response;
   sendBody();
@@ -122,13 +148,13 @@ void MongooseHttpServerRequest::send(MongooseHttpServerResponse *response)
 
 void MongooseHttpServerRequest::sendBody()
 {
-  if(_response) 
+  if(_response)
   {
     size_t free = getConnection()->send.size - getConnection()->send.len;
     if(0 == getConnection()->send.size) {
       free = ARDUINO_MONGOOSE_SEND_BUFFER_SIZE;
     }
-    if(free > 0) 
+    if(free > 0)
     {
       size_t sent = _response->sendBody(getConnection(), free);
       DBUGF("Connection %p: sent %zu/%zu, %d", getConnection(), sent, free, getConnection()->is_draining);
@@ -137,7 +163,26 @@ void MongooseHttpServerRequest::sendBody()
         DBUGLN("Response finished");
         delete _response;
         _response = nullptr;
+        completeRequest();
       }
+    }
+  }
+}
+
+// Mongoose latches c->is_resp while a response is being generated and will not
+// dispatch the next request until it is cleared (see http_cb). Clearing it here
+// hands the connection back: in keep-alive mode Mongoose keeps it open for the
+// next request, otherwise we drain it and close as before.
+void MongooseHttpServerRequest::completeRequest()
+{
+  _completed = true;
+  _lastActivity = mg_millis();
+
+  mg_connection *nc = getConnection();
+  if(nc) {
+    nc->is_resp = 0;
+    if(!_keepAlive) {
+      nc->is_draining = 1;
     }
   }
 }
@@ -150,14 +195,15 @@ void MongooseHttpServerRequest::send(int code) {
 void MongooseHttpServerRequest::send(int code, const char *contentType, const char *content)
 {
   char headers[128];
-  mg_snprintf(headers, sizeof(headers), 
-      "Connection: close\r\n"
+  mg_snprintf(headers, sizeof(headers),
+      "Connection: %s\r\n"
       "Content-Type: %s\r\n",
+      _keepAlive ? "keep-alive" : "close",
       contentType);
 
   mg_http_reply(getConnection(), code, headers, "%s", content);
 
-  getConnection()->is_draining = 1;
+  completeRequest();
 
   _responseSent = true;
 }
@@ -297,11 +343,13 @@ void MongooseHttpServerRequest::requestAuthentication(const char* realm)
 {
   char headers[256];
   mg_snprintf(headers, sizeof(headers),
+      "Connection: %s\r\n"
       "WWW-Authenticate: Basic realm=%s\r\n",
+      _keepAlive ? "keep-alive" : "close",
       realm ? realm : "");
 
   mg_http_reply(getConnection(), 401, headers, "");
-  getConnection()->is_draining = 1;
+  completeRequest();
 
   _responseSent = true;
 }
@@ -320,7 +368,36 @@ void MongooseHttpServerRequest::handlePoll(mg_connection *nc)
 {
   if(responseSent()) {
     sendBody();
+    return;
   }
+
+  // Reap a kept-alive connection that has been parked idle for too long.
+  if(_completed && _keepAlive &&
+     (mg_millis() - _lastActivity) >= _server->keepAliveTimeout()) {
+    DBUGF("Connection %p: keep-alive idle timeout", nc);
+    nc->is_draining = 1;
+  }
+}
+
+void MongooseHttpServerRequest::handleHeaders(mg_connection *nc, mg_http_message *msg)
+{
+  // Headers for the FIRST request are matched by the server; this override only
+  // fires for a further request arriving on a kept-alive connection this request
+  // already answered. Hand it back to the server for fresh endpoint matching,
+  // which installs a new request as the connection handler, then retire this one.
+  if(!_completed) {
+    return;
+  }
+
+  _server->handleHeaders(nc, msg);
+
+  // If matching did not install a new handler (404 handler aside, e.g. a 405 or
+  // 500) the connection still points at this request; detach before freeing so
+  // the pending close does not dispatch to freed memory.
+  if(nc->fn_data == this) {
+    nc->fn_data = nullptr;
+  }
+  delete this;
 }
 
 void MongooseHttpServerRequest::handleMessage(mg_connection *nc, mg_http_message *msg)

--- a/src/MongooseHttpServerRequest.h
+++ b/src/MongooseHttpServerRequest.h
@@ -17,6 +17,7 @@
 #define MG_COPY_HTTP_MESSAGE 1
 #endif
 
+class MongooseHttpServer;
 class MongooseHttpServerEndpoint;
 
  /**
@@ -26,17 +27,41 @@ class MongooseHttpServerRequest : public MongooseHttpServerConnection, public Mo
 {
   private:
     void handlePoll(mg_connection *nc);
-    void handleSend(mg_connection *nc, int num_bytes) {
-      handlePoll(nc);
-    }
     void handleClose(mg_connection *nc);
     void handleMessage(mg_connection *nc, mg_http_message *msg);
+    // A completed keep-alive request whose connection is being reused: hand the
+    // fresh request headers back to the server for endpoint matching.
+    void handleHeaders(mg_connection *nc, mg_http_message *msg) override;
+
+    // Negotiate keep-alive for this request from the protocol version, the
+    // client's Connection header and the server's current willingness.
+    bool negotiateKeepAlive(mg_http_message *msg);
+    // Mark the response finished: release Mongoose's response latch and either
+    // close the connection (close mode) or leave it open for the next request
+    // and arm the idle reaper (keep-alive mode).
+    void completeRequest();
+
+    // Kept-alive connections are reused; the request object lives as the
+    // connection's handler and must be freed on close and polled while idle.
+    void onClose(mg_connection *nc) override {
+      handleClose(nc);
+    }
+    void onPoll(mg_connection *nc) override {
+      handlePoll(nc);
+    }
+    void onSend(mg_connection *nc, long num_bytes) override {
+      handlePoll(nc);
+    }
 
   protected:
     HttpRequestMethodComposite _method;
     MongooseHttpServerResponse *_response;
     MongooseHttpServerEndpoint *_endpoint;
     bool _responseSent;
+    MongooseHttpServer *_server;
+    bool _keepAlive;
+    bool _completed;
+    uint64_t _lastActivity;
 
     void sendBody();
 
@@ -45,11 +70,25 @@ class MongooseHttpServerRequest : public MongooseHttpServerConnection, public Mo
 #endif
 
   public:
-    MongooseHttpServerRequest(mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg, MongooseHttpServerEndpoint *endpoint);
+    MongooseHttpServerRequest(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg, MongooseHttpServerEndpoint *endpoint);
     virtual ~MongooseHttpServerRequest();
 
     virtual bool isUpload() { return false; }
     virtual bool isWebSocket() { return false; }
+
+    // True when the connection will be kept open for further requests once this
+    // response completes.
+    bool keepAlive() const {
+      return _keepAlive;
+    }
+    // Close the connection after this response even if the client asked to keep
+    // it alive. Must be called before the response is sent.
+    void forceClose() {
+      _keepAlive = false;
+    }
+    bool completed() const {
+      return _completed;
+    }
 
     HttpRequestMethodComposite method() {
       return _method;

--- a/src/MongooseHttpServerRequest.h
+++ b/src/MongooseHttpServerRequest.h
@@ -29,16 +29,36 @@ class MongooseHttpServerRequest : public MongooseHttpServerConnection, public Mo
     void handlePoll(mg_connection *nc);
     void handleClose(mg_connection *nc);
     void handleMessage(mg_connection *nc, mg_http_message *msg);
-    // A completed keep-alive request whose connection is being reused: hand the
-    // fresh request headers back to the server for endpoint matching.
+    /**
+     * @brief Handle a new request arriving on a reused keep-alive connection
+     *
+     * A completed keep-alive request whose connection is being reused: hand the
+     * fresh request headers back to the server for endpoint matching.
+     *
+     * @param nc the Mongoose connection being reused
+     * @param msg the new request's parsed headers
+     */
     void handleHeaders(mg_connection *nc, mg_http_message *msg) override;
 
-    // Negotiate keep-alive for this request from the protocol version, the
-    // client's Connection header and the server's current willingness.
+    /**
+     * @brief Negotiate keep-alive for this request
+     *
+     * Decided from the protocol version (HTTP/1.1 defaults on), the client's
+     * Connection header and the server's current willingness.
+     *
+     * @param msg the request's parsed headers
+     * @return true if the connection may be kept alive after the response
+     * @return false if the connection should close after the response
+     */
     bool negotiateKeepAlive(mg_http_message *msg);
-    // Mark the response finished: release Mongoose's response latch and either
-    // close the connection (close mode) or leave it open for the next request
-    // and arm the idle reaper (keep-alive mode).
+
+    /**
+     * @brief Mark the response finished
+     *
+     * Releases Mongoose's response latch and either closes the connection
+     * (close mode) or leaves it open for the next request and arms the idle
+     * reaper (keep-alive mode).
+     */
     void completeRequest();
 
     // Kept-alive connections are reused; the request object lives as the
@@ -76,16 +96,33 @@ class MongooseHttpServerRequest : public MongooseHttpServerConnection, public Mo
     virtual bool isUpload() { return false; }
     virtual bool isWebSocket() { return false; }
 
-    // True when the connection will be kept open for further requests once this
-    // response completes.
+    /**
+     * @brief Check if the connection will be kept open after this response
+     *
+     * @return true if the connection will be reused for further requests
+     * @return false if the connection closes once the response completes
+     */
     bool keepAlive() const {
       return _keepAlive;
     }
-    // Close the connection after this response even if the client asked to keep
-    // it alive. Must be called before the response is sent.
+
+    /**
+     * @brief Close the connection after this response
+     *
+     * Overrides the negotiated keep-alive, e.g. for handlers that know the
+     * connection should not be reused. Must be called before the response is
+     * sent.
+     */
     void forceClose() {
       _keepAlive = false;
     }
+
+    /**
+     * @brief Check if the response has been fully sent
+     *
+     * @return true once completeRequest() has run for this request
+     * @return false while the response is still pending or in flight
+     */
     bool completed() const {
       return _completed;
     }

--- a/src/MongooseHttpServerRequestUpload.cpp
+++ b/src/MongooseHttpServerRequestUpload.cpp
@@ -27,11 +27,12 @@
 //     our onReceive() override directly.
 // ---------------------------------------------------------------------------
 MongooseHttpServerRequestUpload::MongooseHttpServerRequestUpload(
+    MongooseHttpServer *server,
     mg_connection *nc,
     HttpRequestMethodComposite method,
     mg_http_message *msg,
     MongooseHttpServerEndpoint *endpoint) :
-  MongooseHttpServerRequest(nc, method, msg, endpoint),
+  MongooseHttpServerRequest(server, nc, method, msg, endpoint),
   index(0),
   _streaming(false),
   _bodyExpected(0),
@@ -41,8 +42,16 @@ MongooseHttpServerRequestUpload::MongooseHttpServerRequestUpload(
       static_cast<MongooseHttpServerEndpointUpload *>(_endpoint);
 
   if(!uploadEndpoint->hasUploadHandler()) {
+    // No upload handler: this endpoint is being used as an ordinary request
+    // handler, so leave the keep-alive negotiation from the base class intact.
     return;
   }
+
+  // A real upload: the raw-body path below detaches Mongoose's HTTP handler
+  // (c->pfn = NULL) so the connection can no longer parse a following request,
+  // and multipart consumers finalise on the connection-close event. Uploads
+  // must therefore stay close-based.
+  _keepAlive = false;
 
   // Detect multipart by looking for a "boundary" parameter in Content-Type.
   // If present, let Mongoose buffer the full body and use mg_http_next_multipart().

--- a/src/MongooseHttpServerRequestUpload.h
+++ b/src/MongooseHttpServerRequestUpload.h
@@ -29,7 +29,8 @@ class MongooseHttpServerRequestUpload : public MongooseHttpServerRequest
     void onReceive(mg_connection *nc, long num_bytes) override;
 
   public:
-    MongooseHttpServerRequestUpload(mg_connection *nc,
+    MongooseHttpServerRequestUpload(MongooseHttpServer *server,
+                                    mg_connection *nc,
                                     HttpRequestMethodComposite method,
                                     mg_http_message *msg,
                                     MongooseHttpServerEndpoint *endpoint);

--- a/src/MongooseHttpServerResponse.cpp
+++ b/src/MongooseHttpServerResponse.cpp
@@ -14,7 +14,8 @@ MongooseHttpServerResponse::MongooseHttpServerResponse() :
   _code(200),
   _contentType(nullptr),
   _contentLength(-1),
-  _headerBuffer(nullptr)
+  _headerBuffer(nullptr),
+  _keepAlive(false)
 {
 
 }
@@ -107,11 +108,12 @@ void MongooseHttpServerResponse::sendHeaders(struct mg_connection *nc)
     "HTTP/1.1 %d %s\r\n"
     "Content-Type: %s\r\n"
     "Content-Length: %llu\r\n"
-    "Connection: close\r\n"
+    "Connection: %s\r\n"
     "%s\r\n",
     _code, mg_http_status_code_str(_code),
     _contentType ? _contentType : "text/plain",
-    _contentLength, _headerBuffer ? _headerBuffer : "");
+    _contentLength, _keepAlive ? "keep-alive" : "close",
+    _headerBuffer ? _headerBuffer : "");
 
   if(_headerBuffer) {
     free(_headerBuffer);

--- a/src/MongooseHttpServerResponse.h
+++ b/src/MongooseHttpServerResponse.h
@@ -25,6 +25,9 @@ class MongooseHttpServerResponse
 
     char * _headerBuffer;
 
+  protected:
+    bool _keepAlive;
+
   public:
     MongooseHttpServerResponse();
     virtual ~MongooseHttpServerResponse();
@@ -47,6 +50,9 @@ class MongooseHttpServerResponse
      */
     void setContentLength(int64_t contentLength) {
       _contentLength = contentLength;
+    }
+    void setKeepAlive(bool keepAlive) {
+      _keepAlive = keepAlive;
     }
 
     /**

--- a/src/MongooseHttpServerResponse.h
+++ b/src/MongooseHttpServerResponse.h
@@ -51,6 +51,15 @@ class MongooseHttpServerResponse
     void setContentLength(int64_t contentLength) {
       _contentLength = contentLength;
     }
+    /**
+     * @brief Set the connection behaviour advertised by this response
+     *
+     * Controls whether the response carries a "Connection: keep-alive" or
+     * "Connection: close" header. Set from the request's negotiated state when
+     * the response is sent.
+     *
+     * @param keepAlive true to advertise keep-alive, false to advertise close
+     */
     void setKeepAlive(bool keepAlive) {
       _keepAlive = keepAlive;
     }

--- a/src/MongooseHttpServerResponseBasic.cpp
+++ b/src/MongooseHttpServerResponseBasic.cpp
@@ -39,9 +39,8 @@ size_t MongooseHttpServerResponseBasic::sendBody(struct mg_connection *nc, size_
   ptr += send;
   len -= send;
 
-  if(0 == len) {
-    nc->is_draining = 1;
-  }
+  // Connection teardown (or keep-alive reuse) is decided once the body is fully
+  // sent, in MongooseHttpServerRequest::completeRequest().
 
   return send;
 }

--- a/src/MongooseHttpServerResponseStream.cpp
+++ b/src/MongooseHttpServerResponseStream.cpp
@@ -42,9 +42,8 @@ size_t MongooseHttpServerResponseStream::sendBody(struct mg_connection *nc, size
 
   mg_iobuf_del(&_content, 0, send);
 
-  if(0 == _content.len) {
-    nc->is_draining = 1;
-  }
+  // Connection teardown (or keep-alive reuse) is decided once the body is fully
+  // sent, in MongooseHttpServerRequest::completeRequest().
 
   return send;
 }

--- a/src/MongooseHttpWebSocketConnection.cpp
+++ b/src/MongooseHttpWebSocketConnection.cpp
@@ -9,9 +9,14 @@
 #include "MongooseHttpWebSocketConnection.h"
 #include "MongooseHttpServerEndpointWebSocket.h"
 
-MongooseHttpWebSocketConnection::MongooseHttpWebSocketConnection(mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg, MongooseHttpServerEndpoint *endpoint) :
-  MongooseHttpServerRequest(nc, method, msg, endpoint)
+MongooseHttpWebSocketConnection::MongooseHttpWebSocketConnection(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg, MongooseHttpServerEndpoint *endpoint) :
+  MongooseHttpServerRequest(server, nc, method, msg, endpoint)
 {
+  // WebSocket connections manage their own full-duplex lifetime; the HTTP
+  // keep-alive machinery (completion latch, idle reaper, request re-dispatch)
+  // must leave them alone.
+  _keepAlive = false;
+
   // Upgrade to websocket. From now on, a connection is a full-duplex
   // Websocket connection, which will receive MG_EV_WS_MSG events.
   mg_ws_upgrade(nc, msg, NULL);

--- a/src/MongooseHttpWebSocketConnection.h
+++ b/src/MongooseHttpWebSocketConnection.h
@@ -19,7 +19,7 @@ class MongooseHttpWebSocketConnection : public MongooseHttpServerRequest
     void handleWebSocketControl(mg_connection *nc, mg_ws_message *msg);
 
   public:
-    MongooseHttpWebSocketConnection(mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg, MongooseHttpServerEndpoint *endpoint);
+    MongooseHttpWebSocketConnection(MongooseHttpServer *server, mg_connection *nc, HttpRequestMethodComposite method, mg_http_message *msg, MongooseHttpServerEndpoint *endpoint);
     virtual ~MongooseHttpWebSocketConnection();
 
     virtual bool isWebSocket() { return true; }

--- a/tests/unit/test/test_http_server.cpp
+++ b/tests/unit/test/test_http_server.cpp
@@ -529,6 +529,253 @@ static void test_raw_body_upload_large()
   TEST_ASSERT_GREATER_THAN(0, dataCallCount);
 }
 
+// ---------------------------------------------------------------------------
+// Keep-alive coverage.
+//
+// The in-process MongooseHttpClient always sends "Connection: close", so these
+// tests drive the server with a raw HTTP/1.1 client (mg_http_connect) that can
+// negotiate keep-alive and reuse the socket for a second request.
+// ---------------------------------------------------------------------------
+namespace {
+
+struct RawResponse {
+  int code = 0;
+  std::string connection;  // value of the response Connection header
+  std::string body;
+};
+
+// A minimal HTTP/1.1 client that sends a queued list of raw requests, one after
+// each response, all on the same connection.
+struct RawKeepAliveClient {
+  std::vector<std::string> requests;
+  size_t sent = 0;
+  std::vector<RawResponse> responses;
+  bool connected = false;
+  bool closed = false;
+  bool errored = false;
+
+  void sendNext(mg_connection *c) {
+    if (sent < requests.size()) {
+      mg_send(c, requests[sent].data(), requests[sent].size());
+      sent++;
+    }
+  }
+
+  static void handler(mg_connection *c, int ev, void *ev_data) {
+    RawKeepAliveClient *self = static_cast<RawKeepAliveClient *>(c->fn_data);
+    if (ev == MG_EV_CONNECT) {
+      self->connected = true;
+      self->sendNext(c);
+    } else if (ev == MG_EV_HTTP_MSG) {
+      mg_http_message *hm = static_cast<mg_http_message *>(ev_data);
+      RawResponse r;
+      r.code = mg_http_status(hm);
+      mg_str *cc = mg_http_get_header(hm, "Connection");
+      if (cc) {
+        r.connection.assign(cc->buf, cc->len);
+      }
+      r.body.assign(hm->body.buf, hm->body.len);
+      self->responses.push_back(r);
+      self->sendNext(c);  // reuse the connection for the next queued request
+    } else if (ev == MG_EV_ERROR) {
+      self->errored = true;
+    } else if (ev == MG_EV_CLOSE) {
+      self->closed = true;
+    }
+  }
+};
+
+static size_t managerConnectionCount() {
+  size_t count = 0;
+  for (mg_connection *c = Mongoose.getMgr()->conns; c != nullptr; c = c->next) {
+    count++;
+  }
+  return count;
+}
+
+static void nopHandler(mg_connection * /*c*/, int /*ev*/, void * /*ev_data*/) {}
+
+}  // namespace
+
+static void test_http_server_keepalive_reuses_connection() {
+  ScopedMongoose mongoose;
+  MongooseHttpServer server;
+  TEST_ASSERT_TRUE(server.begin(18101));
+
+  int hits = 0;
+  server.on("/ka", HTTP_GET, [&hits](MongooseHttpServerRequest *request) {
+    hits++;
+    TEST_ASSERT_TRUE_MESSAGE(request->keepAlive(), "HTTP/1.1 request should negotiate keep-alive");
+    request->send(200, "text/plain", "ka");
+  });
+
+  RawKeepAliveClient client;
+  client.requests.push_back("GET /ka HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+  client.requests.push_back("GET /ka HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+  mg_connection *c = mg_http_connect(Mongoose.getMgr(), "http://127.0.0.1:18101",
+                                     RawKeepAliveClient::handler, &client);
+  TEST_ASSERT_NOT_NULL(c);
+
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([&client]() { return client.responses.size() >= 2; }, 3000),
+      "expected two responses on a single kept-alive connection");
+
+  TEST_ASSERT_EQUAL(2, client.responses.size());
+  TEST_ASSERT_EQUAL(2, hits);
+  TEST_ASSERT_EQUAL(200, client.responses[0].code);
+  TEST_ASSERT_EQUAL_STRING("keep-alive", client.responses[0].connection.c_str());
+  TEST_ASSERT_EQUAL_STRING("ka", client.responses[0].body.c_str());
+  TEST_ASSERT_EQUAL_STRING("ka", client.responses[1].body.c_str());
+  TEST_ASSERT_FALSE_MESSAGE(client.closed,
+      "connection must stay open across keep-alive responses");
+}
+
+static void test_http_server_keepalive_explicit_close() {
+  ScopedMongoose mongoose;
+  MongooseHttpServer server;
+  TEST_ASSERT_TRUE(server.begin(18102));
+
+  server.on("/ka", HTTP_GET, [](MongooseHttpServerRequest *request) {
+    TEST_ASSERT_FALSE_MESSAGE(request->keepAlive(),
+        "explicit Connection: close must defeat keep-alive");
+    request->send(200, "text/plain", "bye");
+  });
+
+  RawKeepAliveClient client;
+  client.requests.push_back(
+      "GET /ka HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n");
+
+  TEST_ASSERT_NOT_NULL(mg_http_connect(Mongoose.getMgr(), "http://127.0.0.1:18102",
+                                       RawKeepAliveClient::handler, &client));
+
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([&client]() { return client.closed; }, 3000),
+      "connection should close after an explicit Connection: close request");
+
+  TEST_ASSERT_EQUAL(1, client.responses.size());
+  TEST_ASSERT_EQUAL_STRING("close", client.responses[0].connection.c_str());
+}
+
+static void test_http_server_keepalive_disabled() {
+  ScopedMongoose mongoose;
+  MongooseHttpServer server;
+  TEST_ASSERT_TRUE(server.begin(18103));
+  server.enableKeepAlive(false);
+
+  server.on("/ka", HTTP_GET, [](MongooseHttpServerRequest *request) {
+    TEST_ASSERT_FALSE_MESSAGE(request->keepAlive(),
+        "enableKeepAlive(false) must force close mode");
+    request->send(200, "text/plain", "x");
+  });
+
+  RawKeepAliveClient client;
+  client.requests.push_back("GET /ka HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+  TEST_ASSERT_NOT_NULL(mg_http_connect(Mongoose.getMgr(), "http://127.0.0.1:18103",
+                                       RawKeepAliveClient::handler, &client));
+
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([&client]() { return client.closed; }, 3000),
+      "connection should close when keep-alive is disabled");
+
+  TEST_ASSERT_EQUAL(1, client.responses.size());
+  TEST_ASSERT_EQUAL_STRING("close", client.responses[0].connection.c_str());
+}
+
+static void test_http_server_force_close() {
+  ScopedMongoose mongoose;
+  MongooseHttpServer server;
+  TEST_ASSERT_TRUE(server.begin(18104));
+
+  server.on("/ka", HTTP_GET, [](MongooseHttpServerRequest *request) {
+    request->forceClose();
+    request->send(200, "text/plain", "x");
+  });
+
+  RawKeepAliveClient client;
+  client.requests.push_back("GET /ka HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+  TEST_ASSERT_NOT_NULL(mg_http_connect(Mongoose.getMgr(), "http://127.0.0.1:18104",
+                                       RawKeepAliveClient::handler, &client));
+
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([&client]() { return client.closed; }, 3000),
+      "forceClose() should close the connection after the response");
+
+  TEST_ASSERT_EQUAL(1, client.responses.size());
+  TEST_ASSERT_EQUAL_STRING("close", client.responses[0].connection.c_str());
+}
+
+static void test_http_server_keepalive_idle_timeout() {
+  ScopedMongoose mongoose;
+  MongooseHttpServer server;
+  TEST_ASSERT_TRUE(server.begin(18105));
+  server.setKeepAliveTimeout(150);  // ms
+
+  server.on("/ka", HTTP_GET, [](MongooseHttpServerRequest *request) {
+    request->send(200, "text/plain", "ka");
+  });
+
+  RawKeepAliveClient client;
+  client.requests.push_back("GET /ka HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+  TEST_ASSERT_NOT_NULL(mg_http_connect(Mongoose.getMgr(), "http://127.0.0.1:18105",
+                                       RawKeepAliveClient::handler, &client));
+
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([&client]() { return !client.responses.empty(); }, 3000),
+      "expected a keep-alive response");
+  TEST_ASSERT_EQUAL_STRING("keep-alive", client.responses[0].connection.c_str());
+  TEST_ASSERT_FALSE(client.closed);
+
+  // The connection is now parked idle and should be reaped after the timeout.
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([&client]() { return client.closed; }, 3000),
+      "idle kept-alive connection should be reaped after the timeout");
+  TEST_ASSERT_EQUAL(1, client.responses.size());
+}
+
+static void test_http_server_keepalive_pool_pressure_veto() {
+  ScopedMongoose mongoose;
+  MongooseHttpServer server;
+  TEST_ASSERT_TRUE(server.begin(18106));
+
+  server.on("/probe", HTTP_GET, [](MongooseHttpServerRequest *request) {
+    TEST_ASSERT_FALSE_MESSAGE(request->keepAlive(),
+        "keep-alive must be vetoed while the manager is over the connection limit");
+    request->send(200, "text/plain", "x");
+  });
+
+  // Hold open enough idle connections to push the manager over
+  // ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS.
+  std::vector<mg_connection *> held;
+  for (int i = 0; i < 12; i++) {
+    mg_connection *c = mg_connect(Mongoose.getMgr(), "tcp://127.0.0.1:18106",
+                                  nopHandler, nullptr);
+    TEST_ASSERT_NOT_NULL(c);
+    held.push_back(c);
+  }
+
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([]() {
+        return managerConnectionCount() > ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS + 1;
+      }, 3000),
+      "failed to establish enough connections to exceed the keep-alive limit");
+
+  RawKeepAliveClient client;
+  client.requests.push_back("GET /probe HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n");
+
+  TEST_ASSERT_NOT_NULL(mg_http_connect(Mongoose.getMgr(), "http://127.0.0.1:18106",
+                                       RawKeepAliveClient::handler, &client));
+
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([&client]() { return !client.responses.empty(); }, 3000),
+      "expected a response to the probe request");
+
+  TEST_ASSERT_EQUAL_STRING("close", client.responses[0].connection.c_str());
+}
+
 static void test_https_server_tls_handshake_succeeds() {
   ScopedMongoose mongoose;
   MongooseHttpServer server;
@@ -575,5 +822,11 @@ void runHttpServerTests() {
   RUN_TEST(test_multipart_upload_auth_rejection);
   RUN_TEST(test_raw_body_upload_basic);
   RUN_TEST(test_raw_body_upload_large);
+  RUN_TEST(test_http_server_keepalive_reuses_connection);
+  RUN_TEST(test_http_server_keepalive_explicit_close);
+  RUN_TEST(test_http_server_keepalive_disabled);
+  RUN_TEST(test_http_server_force_close);
+  RUN_TEST(test_http_server_keepalive_idle_timeout);
+  RUN_TEST(test_http_server_keepalive_pool_pressure_veto);
   RUN_TEST(test_https_server_tls_handshake_succeeds);
 }


### PR DESCRIPTION
Fixes #87 

This is the Mongoose 7 counterpart of #79, so the keep-alive behaviour lands in the #38 line of work too. Same motivation: the server closes every connection after a single response, so polling clients (Home Assistant, a dashboard tab) burn a fresh TCP connection per request, and on ESP32 LWIP's small connection pool gets exhausted — I traced OTA transfers being reset mid-flight to exactly that.

Same semantics as #79:

- **Per-request negotiation.** HTTP/1.1 defaults to keep-alive, HTTP/1.0 to close, an explicit `Connection` header from the client wins either way, and the response advertises the negotiated behaviour.
- **Pool-pressure veto.** Keep-alive is refused while the manager already holds more than `ARDUINO_MONGOOSE_KEEPALIVE_MAX_CONNECTIONS` (default 8) connections. `server.enableKeepAlive(false)` restores close-per-request entirely; `request->forceClose()` opts a single request out.
- **Idle reaping.** A parked kept-alive connection is closed after `ARDUINO_MONGOOSE_KEEPALIVE_TIMEOUT` (default 30 s, runtime-overridable via `setKeepAliveTimeout()`). Both defaults are compile-time overridable.
- **Exemptions.** Uploads stay close-based (the raw-body escape hatch detaches Mongoose's HTTP handler so the connection can't parse a follow-on request, and multipart consumers finalise on close) — but only when the endpoint actually has an upload handler, so ordinary requests routed through the upload-capable endpoint type still keep alive. WebSockets are untouched.

The implementation is a rewrite rather than a port, because Mongoose 7 already has the right primitive: `http_cb` latches `c->is_resp` before `MG_EV_HTTP_MSG` and won't dispatch the next request until it's cleared. The wrapper never cleared it and forced `is_draining` everywhere, which is why every connection closed. `completeRequest()` now owns the teardown decision: it clears `is_resp` when a response is fully generated and only drains in close mode. Since the request object is the connection's event handler (`nc->fn_data`), a completed keep-alive request stays attached until the next request's headers arrive, at which point it hands them back to the server for fresh endpoint matching and retires.

Two things I found along the way, fixed here because keep-alive depends on correct teardown:

- `handleClose`/`handlePoll` on server requests were never wired up, so request objects leaked on every request and endpoint `onClose` callbacks never fired. They're now connected (`onClose`/`onPoll`/`onSend` overrides); close-mode wire behaviour is unchanged.
- The response body writers each set `is_draining` themselves; that decision now lives solely in `completeRequest()`.

Testing: six new native unit tests (connection reuse across two requests on one socket, explicit `Connection: close`, `enableKeepAlive(false)`, `forceClose()`, the idle reaper, and the pool-pressure veto with >8 held connections) — suite goes 48→54 cases, all green. `examples/simple_http_server` builds for ESP32 (esp-wrover-kit). The negotiation/veto/reaping behaviour matches what I hardware-tested for #79 on an OpenEVSE ESP32 build, including the OTA-under-polling scenario that motivated this.
