### PR TITLE
Fix two use-after-frees: request URI/body ownership, and socket detach on delete

### DIFF
--- a/src/MongooseHttpClient.cpp
+++ b/src/MongooseHttpClient.cpp
@@ -34,7 +34,15 @@ bool MongooseHttpClient::get(const char *uri, MongooseHttpResponseHandler onResp
   if(nullptr != onClose) {
     request->onClose(onClose);
   }
-  return request->send();
+  // A successful send() self-deletes from onClose() once mongoose is done with
+  // it. A failed send() never connects, so onClose() never fires and nothing
+  // else references this request -- this convenience wrapper handed back only
+  // a bool, so it must clean up itself rather than leaking on every failure.
+  if(request->send()) {
+    return true;
+  }
+  delete request;
+  return false;
 }
 
 bool MongooseHttpClient::post(const char* uri, const char *contentType, const char *body, MongooseHttpResponseHandler onResponse, MongooseSocketCloseHandler onClose)
@@ -49,7 +57,11 @@ bool MongooseHttpClient::post(const char* uri, const char *contentType, const ch
   if(nullptr != onClose) {
     request->onClose(onClose);
   }
-  return request->send();
+  if(request->send()) {
+    return true;
+  }
+  delete request;
+  return false;
 }
 
 bool MongooseHttpClient::put(const char* uri, const char *contentType, const char *body, MongooseHttpResponseHandler onResponse, MongooseSocketCloseHandler onClose)
@@ -64,7 +76,11 @@ bool MongooseHttpClient::put(const char* uri, const char *contentType, const cha
   if(nullptr != onClose) {
     request->onClose(onClose);
   }
-  return request->send();
+  if(request->send()) {
+    return true;
+  }
+  delete request;
+  return false;
 }
 
 bool MongooseHttpClient::patch(const char* uri, const char *contentType, const char *body, MongooseHttpResponseHandler onResponse, MongooseSocketCloseHandler onClose)
@@ -79,7 +95,11 @@ bool MongooseHttpClient::patch(const char* uri, const char *contentType, const c
   if(nullptr != onClose) {
     request->onClose(onClose);
   }
-  return request->send();
+  if(request->send()) {
+    return true;
+  }
+  delete request;
+  return false;
 }
 
 bool MongooseHttpClient::delete_(const char* uri, MongooseHttpResponseHandler onResponse, MongooseSocketCloseHandler onClose)
@@ -92,7 +112,11 @@ bool MongooseHttpClient::delete_(const char* uri, MongooseHttpResponseHandler on
   if(nullptr != onClose) {
     request->onClose(onClose);
   }
-  return request->send();
+  if(request->send()) {
+    return true;
+  }
+  delete request;
+  return false;
 }
 
 MongooseHttpClientRequest *MongooseHttpClient::beginRequest(const char *uri)

--- a/src/MongooseHttpClient.cpp
+++ b/src/MongooseHttpClient.cpp
@@ -8,11 +8,30 @@
 
 #include <MicroDebug.h>
 
-#include <stdlib.h>  // malloc, free, strdup
-#include <string.h>  // memcpy
+#include <stdlib.h>  // malloc, free
+#include <string.h>  // memcpy, strlen
 
 #include "MongooseCore.h"
 #include "MongooseHttpClient.h"
+
+// mongoose.h #defines strdup(s) to mg_strdup(), which allocates through
+// mg_calloc() -- a custom allocator on builds that provide one (FreeRTOS and
+// friends). Pairing that with plain free(), as this file does for every other
+// buffer it owns, is an allocator mismatch that only shows up on those builds.
+// Duplicate with plain malloc()/memcpy() instead so the pairing is always the
+// same free() already used below.
+static char *dupString(const char *s)
+{
+  if(nullptr == s) {
+    return nullptr;
+  }
+  size_t len = strlen(s) + 1;
+  char *copy = (char *)malloc(len);
+  if(copy) {
+    memcpy(copy, s, len);
+  }
+  return copy;
+}
 
 MongooseHttpClient::MongooseHttpClient()
 {
@@ -128,7 +147,7 @@ MongooseHttpClientRequest::MongooseHttpClientRequest(const char *uri) :
   MongooseSocket(),
   _onResponse(nullptr),
   _onBody(nullptr),
-  _uri(uri ? strdup(uri) : nullptr),
+  _uri(uri ? dupString(uri) : nullptr),
   _method(HTTP_GET),
   _contentType(nullptr),
   _contentLength(-1),
@@ -250,30 +269,39 @@ bool MongooseHttpClientRequest::send()
 MongooseHttpClientRequest *MongooseHttpClientRequest::setContentType(const char *contentType)
 {
   free(_contentType);
-  _contentType = contentType ? strdup(contentType) : nullptr;
+  _contentType = contentType ? dupString(contentType) : nullptr;
   return this;
 }
 
 MongooseHttpClientRequest *MongooseHttpClientRequest::setContent(const uint8_t *content, size_t len)
 {
-  free(_body);
-  _body = nullptr;
-  setContentLength(0);
-
   if(nullptr == content || 0 == len) {
+    free(_body);
+    _body = nullptr;
+    setContentLength(0);
     return this;
   }
 
+  // Allocate before touching any existing state. Freeing the old body and
+  // resetting the length first (as this used to) meant a failed allocation
+  // silently downgraded the request to an empty body instead of the intended
+  // payload -- a caller replacing an already-set body with a bigger one would
+  // lose the good copy it had, with only a debug log to say why. Leave the
+  // previous body/length untouched on failure instead.
+  //
   // +1 and NUL-terminated: callers pass text bodies here via the const char *
   // overload and it costs one byte to keep that safe to print while debugging.
-  _body = (uint8_t *)malloc(len + 1);
-  if(nullptr == _body) {
+  uint8_t *newBody = (uint8_t *)malloc(len + 1);
+  if(nullptr == newBody) {
     DBUGF("Failed to allocate %u bytes for the request body", (unsigned)len);
     return this;
   }
 
-  memcpy(_body, content, len);
-  _body[len] = '\0';
+  memcpy(newBody, content, len);
+  newBody[len] = '\0';
+
+  free(_body);
+  _body = newBody;
   setContentLength(len);
   return this;
 }

--- a/src/MongooseHttpClient.cpp
+++ b/src/MongooseHttpClient.cpp
@@ -8,6 +8,9 @@
 
 #include <MicroDebug.h>
 
+#include <stdlib.h>  // malloc, free, strdup
+#include <string.h>  // memcpy
+
 #include "MongooseCore.h"
 #include "MongooseHttpClient.h"
 
@@ -101,7 +104,7 @@ MongooseHttpClientRequest::MongooseHttpClientRequest(const char *uri) :
   MongooseSocket(),
   _onResponse(nullptr),
   _onBody(nullptr),
-  _uri(uri),
+  _uri(uri ? strdup(uri) : nullptr),
   _method(HTTP_GET),
   _contentType(nullptr),
   _contentLength(-1),
@@ -113,10 +116,14 @@ MongooseHttpClientRequest::MongooseHttpClientRequest(const char *uri) :
 
 MongooseHttpClientRequest::~MongooseHttpClientRequest()
 {
-  if (_extraHeaders) {
-    free(_extraHeaders);
-    _extraHeaders = nullptr;
-  }
+  free(_uri);
+  _uri = nullptr;
+  free(_contentType);
+  _contentType = nullptr;
+  free(_body);
+  _body = nullptr;
+  free(_extraHeaders);
+  _extraHeaders = nullptr;
 }
 
 void MongooseHttpClientRequest::handleEvent(mg_connection *nc, int ev, void *p)
@@ -196,6 +203,11 @@ void MongooseHttpClientRequest::onClose(mg_connection *nc)
 
 bool MongooseHttpClientRequest::send()
 {
+  if(nullptr == _uri) {
+    DBUGF("No URI, was the request allocated with one?");
+    return false;
+  }
+
   if(mg_url_is_ssl(_uri)) {
     setSecure(mg_url_host(_uri));
   }
@@ -211,10 +223,34 @@ bool MongooseHttpClientRequest::send()
   return false;
 }
 
+MongooseHttpClientRequest *MongooseHttpClientRequest::setContentType(const char *contentType)
+{
+  free(_contentType);
+  _contentType = contentType ? strdup(contentType) : nullptr;
+  return this;
+}
+
 MongooseHttpClientRequest *MongooseHttpClientRequest::setContent(const uint8_t *content, size_t len)
 {
+  free(_body);
+  _body = nullptr;
+  setContentLength(0);
+
+  if(nullptr == content || 0 == len) {
+    return this;
+  }
+
+  // +1 and NUL-terminated: callers pass text bodies here via the const char *
+  // overload and it costs one byte to keep that safe to print while debugging.
+  _body = (uint8_t *)malloc(len + 1);
+  if(nullptr == _body) {
+    DBUGF("Failed to allocate %u bytes for the request body", (unsigned)len);
+    return this;
+  }
+
+  memcpy(_body, content, len);
+  _body[len] = '\0';
   setContentLength(len);
-  _body = content;
   return this;
 }
 

--- a/src/MongooseHttpClient.cpp
+++ b/src/MongooseHttpClient.cpp
@@ -69,7 +69,9 @@ bool MongooseHttpClient::post(const char* uri, const char *contentType, const ch
   MongooseHttpClientRequest *request = beginRequest(uri);
   request->setMethod(HTTP_POST);
   request->setContentType(contentType);
-  request->setContent(body);
+  if(nullptr != body) {
+    request->setContent(body);
+  }
   if(nullptr != onResponse) {
     request->onResponse(onResponse);
   }
@@ -88,7 +90,9 @@ bool MongooseHttpClient::put(const char* uri, const char *contentType, const cha
   MongooseHttpClientRequest *request = beginRequest(uri);
   request->setMethod(HTTP_PUT);
   request->setContentType(contentType);
-  request->setContent(body);
+  if(nullptr != body) {
+    request->setContent(body);
+  }
   if(nullptr != onResponse) {
     request->onResponse(onResponse);
   }
@@ -107,7 +111,9 @@ bool MongooseHttpClient::patch(const char* uri, const char *contentType, const c
   MongooseHttpClientRequest *request = beginRequest(uri);
   request->setMethod(HTTP_PATCH);
   request->setContentType(contentType);
-  request->setContent(body);
+  if(nullptr != body) {
+    request->setContent(body);
+  }
   if(nullptr != onResponse) {
     request->onResponse(onResponse);
   }
@@ -268,8 +274,23 @@ bool MongooseHttpClientRequest::send()
 
 MongooseHttpClientRequest *MongooseHttpClientRequest::setContentType(const char *contentType)
 {
+  if(nullptr == contentType) {
+    free(_contentType);
+    _contentType = nullptr;
+    return this;
+  }
+
+  // Same reasoning as setContent(): duplicate first, so a failed allocation
+  // leaves whatever Content-Type was already set rather than silently
+  // dropping it.
+  char *copy = dupString(contentType);
+  if(nullptr == copy) {
+    DBUGF("Failed to allocate content type '%s'", contentType);
+    return this;
+  }
+
   free(_contentType);
-  _contentType = contentType ? dupString(contentType) : nullptr;
+  _contentType = copy;
   return this;
 }
 

--- a/src/MongooseHttpClient.h
+++ b/src/MongooseHttpClient.h
@@ -31,11 +31,15 @@ class MongooseHttpClientRequest : public MongooseSocket
     MongooseHttpResponseHandler _onResponse;
     MongooseHttpResponseHandler _onBody;
 
-    const char *_uri;
+    // Owned copies. send() only starts the connection; the URI, content type
+    // and body are not read until onConnect() fires on a later poll, by which
+    // time a caller's local String or stack buffer is long gone. Holding the
+    // caller's pointers made every such call site a use-after-free.
+    char *_uri;
     HttpRequestMethodComposite _method;
-    const char *_contentType;
+    char *_contentType;
     int64_t _contentLength;
-    const uint8_t *_body;
+    uint8_t *_body;
     char *_extraHeaders;
     uint64_t _timeout_ms;
 
@@ -56,10 +60,7 @@ class MongooseHttpClientRequest : public MongooseSocket
       _method = method;
       return this;
     }
-    MongooseHttpClientRequest *setContentType(const char *contentType) {
-      _contentType = contentType;
-      return this;
-    }
+    MongooseHttpClientRequest *setContentType(const char *contentType);
     MongooseHttpClientRequest *setContentLength(int64_t contentLength) {
       _contentLength = contentLength;
       return this;

--- a/src/MongooseHttpClient.h
+++ b/src/MongooseHttpClient.h
@@ -54,6 +54,18 @@ class MongooseHttpClientRequest : public MongooseSocket
     MongooseHttpClientRequest(const char *uri);
     virtual ~MongooseHttpClientRequest();
 
+    // _uri/_contentType/_body are owned heap buffers now (see above); the
+    // default-generated copy/move would shallow-copy those pointers, so a
+    // copy's destructor freeing them leaves the original dangling, and both
+    // objects' destructors freeing them is a double-free. There is no
+    // legitimate reason to copy or move a request in flight -- it is always
+    // used through a pointer -- so remove the footgun rather than implement
+    // deep-copy semantics nothing needs.
+    MongooseHttpClientRequest(const MongooseHttpClientRequest &) = delete;
+    MongooseHttpClientRequest &operator=(const MongooseHttpClientRequest &) = delete;
+    MongooseHttpClientRequest(MongooseHttpClientRequest &&) = delete;
+    MongooseHttpClientRequest &operator=(MongooseHttpClientRequest &&) = delete;
+
     bool send();
 
     MongooseHttpClientRequest *setMethod(HttpRequestMethodComposite method) {
@@ -66,7 +78,12 @@ class MongooseHttpClientRequest : public MongooseSocket
       return this;
     }
     MongooseHttpClientRequest *setContent(const char *content) {
-      setContent((uint8_t *)content, strlen(content));
+      // setContent(const uint8_t*, size_t) already treats a null/zero-length
+      // body as "no body" -- match that here instead of calling strlen() on
+      // a possible nullptr. The wrappers in MongooseHttpClient.cpp guard
+      // their own nullptr bodies before reaching here, but this overload is
+      // public API in its own right and should not crash on the same input.
+      setContent((const uint8_t *)content, content ? strlen(content) : 0);
       return this;
     }
     MongooseHttpClientRequest *setContent(const uint8_t *content, size_t len);

--- a/src/MongooseSocket.cpp
+++ b/src/MongooseSocket.cpp
@@ -41,6 +41,23 @@ MongooseSocket::MongooseSocket(mg_connection *nc) :
 
 MongooseSocket::~MongooseSocket()
 {
+  // Detach from the connection before we go.
+  //
+  // disconnect() and abort() only *flag* the connection; mongoose does not
+  // actually close and free it until the next mg_mgr_poll(). Until then
+  // nc->fn_data still points here, so an object deleted straight after either
+  // call is dereferenced by eventHandler() on the next MG_EV_POLL. That is a
+  // use-after-free for every subclass the application owns and deletes --
+  // MongooseHttpClientRequest only escapes it by self-deleting from its own
+  // onClose(), which is to say once mongoose has already finished with it.
+  //
+  // eventHandler() already null-checks fn_data, so clearing it makes any
+  // further events on this connection a no-op.
+  if(_nc) {
+    _nc->fn_data = nullptr;
+    _nc->is_closing = 1;
+    _nc = nullptr;
+  }
 }
 
 void MongooseSocket::eventHandler(mg_connection *nc, int ev, void *p)

--- a/src/MongooseSocket.cpp
+++ b/src/MongooseSocket.cpp
@@ -41,7 +41,7 @@ MongooseSocket::MongooseSocket(mg_connection *nc) :
 
 MongooseSocket::~MongooseSocket()
 {
-  // Detach from the connection before we go.
+  // Detach from the connection before we go, but only if we still own it.
   //
   // disconnect() and abort() only *flag* the connection; mongoose does not
   // actually close and free it until the next mg_mgr_poll(). Until then
@@ -51,13 +51,22 @@ MongooseSocket::~MongooseSocket()
   // MongooseHttpClientRequest only escapes it by self-deleting from its own
   // onClose(), which is to say once mongoose has already finished with it.
   //
-  // eventHandler() already null-checks fn_data, so clearing it makes any
-  // further events on this connection a no-op.
-  if(_nc) {
+  // But ownership of nc can also have already passed to a *different* object
+  // before this one is destroyed: on a kept-alive connection,
+  // MongooseHttpServerRequest::handleHeaders() installs a new request as
+  // nc->fn_data for the next request, then deletes the one that just
+  // completed. If we clobbered fn_data/is_closing unconditionally here, that
+  // delete would rip the connection out from under the new owner and every
+  // second request on a kept-alive connection would fail. Only touch the
+  // connection when it is still pointing at us.
+  //
+  // eventHandler() already null-checks fn_data, so clearing it (when it is
+  // ours to clear) makes any further event on this connection a no-op.
+  if(_nc && _nc->fn_data == this) {
     _nc->fn_data = nullptr;
     _nc->is_closing = 1;
-    _nc = nullptr;
   }
+  _nc = nullptr;
 }
 
 void MongooseSocket::eventHandler(mg_connection *nc, int ev, void *p)

--- a/tests/unit/test/test_http_client.cpp
+++ b/tests/unit/test/test_http_client.cpp
@@ -3,6 +3,8 @@
 #include <MongooseHttpClient.h>
 #include <MongooseHttpServer.h>
 
+#include <cstdlib>
+#include <cstring>
 #include <string>
 
 #include "test_support.h"
@@ -207,10 +209,81 @@ static void test_http_client_cancel_aborts_in_flight_request() {
       "close callback was not invoked after cancel()");
 }
 
+static void test_http_client_owns_uri_content_type_and_body_after_return() {
+  // The exact shape of the use-after-free this class's ownership fix
+  // targets: send() only *starts* the connection -- _uri, _contentType and
+  // _body are not read until onConnect(), on a later poll -- so a caller
+  // whose source buffers do not outlive the call used to hand the request
+  // dangling pointers. Free the sources immediately (worse than the original
+  // bug, which only needed them to survive past return) and clobber that
+  // memory with unrelated allocations before send() so a regression would
+  // observably corrupt the request instead of merely being UB that happens
+  // to still work.
+  ScopedMongoose mongoose;
+  MongooseHttpServer server;
+  TEST_ASSERT_TRUE(server.begin(18089));
+
+  std::string receivedUri;
+  std::string receivedContentType;
+  std::string receivedBody;
+  server.on("/scratch", HTTP_POST, [&](MongooseHttpServerRequest *request) {
+    receivedUri.assign(request->uri().c_str(), request->uri().length());
+    receivedContentType.assign(request->contentType().c_str(), request->contentType().length());
+    receivedBody.assign(request->body().c_str(), request->body().length());
+
+    MongooseHttpServerResponseBasic *response = request->beginResponse();
+    response->setCode(200);
+    response->setContent("ok");
+    request->send(response);
+  });
+
+  MongooseHttpClient client;
+  bool closed = false;
+
+  {
+    char *uri = (char *)malloc(64);
+    strcpy(uri, "http://127.0.0.1:18089/scratch");
+    char *contentType = (char *)malloc(32);
+    strcpy(contentType, "text/plain");
+    char *body = (char *)malloc(16);
+    strcpy(body, "scratch-body");
+
+    MongooseHttpClientRequest *request = client.beginRequest(uri);
+    request->setMethod(HTTP_POST);
+    request->setContentType(contentType);
+    request->setContent(body);
+    request->onClose([&closed]() { closed = true; });
+
+    free(uri);
+    free(contentType);
+    free(body);
+
+    // Encourage the allocator to hand that freed memory back out with
+    // different content before send() -- and long before the network I/O
+    // that actually reads it -- runs.
+    for (int i = 0; i < 8; i++) {
+      char *scratch = (char *)malloc(64);
+      memset(scratch, 'X', 64);
+      free(scratch);
+    }
+
+    TEST_ASSERT_TRUE(request->send());
+  }
+
+  TEST_ASSERT_TRUE_MESSAGE(
+      pumpUntil([&closed]() { return closed; }),
+      "request built from freed source buffers timed out");
+
+  TEST_ASSERT_EQUAL_STRING("/scratch", receivedUri.c_str());
+  TEST_ASSERT_EQUAL_STRING("text/plain", receivedContentType.c_str());
+  TEST_ASSERT_EQUAL_STRING("scratch-body", receivedBody.c_str());
+}
+
 void runHttpClientTests() {
   RUN_TEST(test_http_client_get_exposes_status_body_headers_and_onbody);
   RUN_TEST(test_http_client_post_and_put_round_trip);
   RUN_TEST(test_http_client_patch_and_delete);
   RUN_TEST(test_http_client_abort_returns_false_when_not_connected);
   RUN_TEST(test_http_client_cancel_aborts_in_flight_request);
+  RUN_TEST(test_http_client_owns_uri_content_type_and_body_after_return);
 }

--- a/tests/unit/test/test_http_client.cpp
+++ b/tests/unit/test/test_http_client.cpp
@@ -214,11 +214,18 @@ static void test_http_client_owns_uri_content_type_and_body_after_return() {
   // targets: send() only *starts* the connection -- _uri, _contentType and
   // _body are not read until onConnect(), on a later poll -- so a caller
   // whose source buffers do not outlive the call used to hand the request
-  // dangling pointers. Free the sources immediately (worse than the original
-  // bug, which only needed them to survive past return) and clobber that
-  // memory with unrelated allocations before send() so a regression would
-  // observably corrupt the request instead of merely being UB that happens
-  // to still work.
+  // dangling pointers.
+  //
+  // Deliberately does *not* free the source buffers to try to trigger that:
+  // freeing and hoping the allocator hands the memory back out differently
+  // is itself undefined behaviour, is inherently non-deterministic across
+  // allocators/platforms, and would make a real regression here show up as a
+  // hard crash rather than a clean, reportable assertion failure. Instead,
+  // keep the buffers alive but *overwrite* them with different (still valid)
+  // content after send() -- well-defined, deterministic, and if the request
+  // were still holding the caller's raw pointers rather than its own copies,
+  // the server would observably receive the overwritten values instead of
+  // the originals.
   ScopedMongoose mongoose;
   MongooseHttpServer server;
   TEST_ASSERT_TRUE(server.begin(18089));
@@ -240,39 +247,30 @@ static void test_http_client_owns_uri_content_type_and_body_after_return() {
   MongooseHttpClient client;
   bool closed = false;
 
-  {
-    char *uri = (char *)malloc(64);
-    strcpy(uri, "http://127.0.0.1:18089/scratch");
-    char *contentType = (char *)malloc(32);
-    strcpy(contentType, "text/plain");
-    char *body = (char *)malloc(16);
-    strcpy(body, "scratch-body");
+  char uri[64];
+  strcpy(uri, "http://127.0.0.1:18089/scratch");
+  char contentType[32];
+  strcpy(contentType, "text/plain");
+  char body[16];
+  strcpy(body, "scratch-body");
 
-    MongooseHttpClientRequest *request = client.beginRequest(uri);
-    request->setMethod(HTTP_POST);
-    request->setContentType(contentType);
-    request->setContent(body);
-    request->onClose([&closed]() { closed = true; });
+  MongooseHttpClientRequest *request = client.beginRequest(uri);
+  request->setMethod(HTTP_POST);
+  request->setContentType(contentType);
+  request->setContent(body);
+  request->onClose([&closed]() { closed = true; });
 
-    free(uri);
-    free(contentType);
-    free(body);
+  TEST_ASSERT_TRUE(request->send());
 
-    // Encourage the allocator to hand that freed memory back out with
-    // different content before send() -- and long before the network I/O
-    // that actually reads it -- runs.
-    for (int i = 0; i < 8; i++) {
-      char *scratch = (char *)malloc(64);
-      memset(scratch, 'X', 64);
-      free(scratch);
-    }
-
-    TEST_ASSERT_TRUE(request->send());
-  }
+  // Overwrite in place, still well within each buffer's allocated size, right
+  // after send() and before any poll has had a chance to read them.
+  strcpy(uri, "http://CLOBBERED");
+  strcpy(contentType, "text/CLOBBERED");
+  strcpy(body, "CLOBBERED-BODY");
 
   TEST_ASSERT_TRUE_MESSAGE(
       pumpUntil([&closed]() { return closed; }),
-      "request built from freed source buffers timed out");
+      "request timed out");
 
   TEST_ASSERT_EQUAL_STRING("/scratch", receivedUri.c_str());
   TEST_ASSERT_EQUAL_STRING("text/plain", receivedContentType.c_str());


### PR DESCRIPTION
Two use-after-frees with the same shape — an object is read, or reached, after the caller reasonably believes it is done with. Both were caught by AddressSanitizer while running OpenEVSE's load sharing integration tests (OpenEVSE/openevse_esp32_firmware#1155), where two instances exchanging peer state segfaulted within seconds of the first reciprocal add.

## 1. `MongooseHttpClientRequest` did not own its URI, content type or body

It kept the caller's pointers. On Mongoose 6 that was safe: `MongooseHttpClient::send()` consumed `_uri` synchronously inside `mg_connect_http_opt()`. On v7, `send()` only *starts* the connection and the URI is not read until `onConnect()` fires on a later poll — by which time a caller's local `String` or stack buffer is long gone.

```cpp
MongooseHttpClientRequest *r = client.beginRequest((base + "/status").c_str());
r->send();   // reads freed memory on the next poll
```

```
ERROR: AddressSanitizer: heap-use-after-free
    #0 urlparse mongoose.c:25339
    #1 mg_url_host mongoose.c:25364
    #2 MongooseHttpClientRequest::onConnect  MongooseHttpClient.cpp:164
freed by:
    #1 String::~String()
    #2 LoadSharingPeerPoller::startHttpBootstrap
```

`setContent()` and `setContentType()` had the same problem — `_body` is sent from `onConnect()` too. Now all three are copied; `_extraHeaders` already was.

## 2. `~MongooseSocket()` was empty, so `delete` left `nc->fn_data` dangling

`disconnect()` and `abort()` only *flag* the connection (`is_draining` / `is_closing`); mongoose does not actually close and free it until the next `mg_mgr_poll()`. Until then `nc->fn_data` still points at the object, so anything deleted straight after either call is dereferenced by `eventHandler()` on the next `MG_EV_POLL`:

```cpp
conn.wsClient->disconnect();
delete conn.wsClient;   // mongoose still has this pointer
```

```
ERROR: AddressSanitizer: heap-use-after-free
    #0 MongooseSocket::processEvent  MongooseSocket.cpp:64   (onPoll)
freed by:
    #1 LoadSharingPeerPoller::disconnectPeer
```

This affects any subclass the application owns and deletes. `MongooseHttpClientRequest` only escapes it by self-deleting from its own `onClose()` — i.e. once mongoose has already finished with it — which is not a pattern the other clients follow.

The destructor now clears `fn_data` and flags the connection closing. `eventHandler()` already null-checks `fn_data`, so any further events on that connection become a no-op. When the connection has already closed, `_nc` is null and the destructor does nothing.

## Testing

Both paths are exercised by the OpenEVSE load sharing integration suite. Before: a hard crash within seconds of the first reciprocal add. After: clean under ASan, and the suite goes from a crash to 70 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)