### PR TITLE
Add MQTT keepalive interval configuration support

### DIFF
--- a/src/MongooseHttpServerRequest.h
+++ b/src/MongooseHttpServerRequest.h
@@ -13,6 +13,13 @@
 // callback. Setting to 0 will save some runtime memory but accessing the HTTP
 // message details outside of the onReceive callback will give undefined behaviour.
 // The body may not allways be avalible even in onReceive, eg file upload
+//
+// Even with this on, body() is never copied -- it stays a pointer into
+// Mongoose's receive buffer for the lifetime of the request, valid only for
+// the duration of the request handler call (MongooseHttpServerEndpoint's
+// onRequest, invoked synchronously from handleMessage()). Reading it from a
+// deferred/async continuation after the handler has returned is undefined
+// behaviour, since Mongoose reclaims that buffer once the event completes.
 #ifndef MG_COPY_HTTP_MESSAGE
 #define MG_COPY_HTTP_MESSAGE 1
 #endif

--- a/src/MongooseMqttClient.cpp
+++ b/src/MongooseMqttClient.cpp
@@ -20,6 +20,7 @@ MongooseMqttClient::MongooseMqttClient() :
   _will_message(),
   _will_retain(false),
   _connected(false),
+  _keepalive(60),
   _onConnect(nullptr),
   _onMessage(nullptr),
   _onDisconnect(nullptr),
@@ -125,6 +126,7 @@ bool MongooseMqttClient::connect(MongooseMqttProtocol protocol, const char *serv
       .client_id = mg_str_s(client_id),
       .topic = _will_topic,
       .message = _will_message,
+      .keepalive = _keepalive,
       .retain = _will_retain,
       .clean = true
     };

--- a/src/MongooseMqttClient.h
+++ b/src/MongooseMqttClient.h
@@ -38,6 +38,7 @@ class MongooseMqttClient : public MongooseSocket
     MongooseString _will_message;
     bool _will_retain;
     bool _connected;
+    uint16_t _keepalive;
 
     MongooseMqttConnectionHandler _onConnect;
     MongooseMqttMessageHandler _onMessage;
@@ -125,6 +126,25 @@ class MongooseMqttClient : public MongooseSocket
       _will_topic = topic;
       _will_message = message;
       _will_retain = retain;
+    }
+
+    /**
+     * @brief Set the CONNECT keepalive interval
+     *
+     * Mongoose 7 sends this value to the broker verbatim, and 0 means "no
+     * timeout" -- unlike 6.18, which silently substituted 60 for a 0 here.
+     * With no keepalive the broker never notices an ungraceful disconnect
+     * (power loss, WiFi drop), so it never fires the Last Will. Defaults to
+     * 60s; pass 0 to opt back into "no timeout" explicitly.
+     *
+     * @param seconds Keepalive interval in seconds, or 0 to disable
+     */
+    void setKeepAlive(uint16_t seconds) {
+      _keepalive = seconds;
+    }
+
+    uint16_t keepAlive() const {
+      return _keepalive;
     }
 
     // Correct-spelling alias; setLastWillAndTestimment kept for backward compatibility

--- a/tests/unit/test/test_mqtt_client.cpp
+++ b/tests/unit/test/test_mqtt_client.cpp
@@ -40,6 +40,22 @@ static void test_mqtt_api_setters_compile_and_do_not_crash() {
   TEST_ASSERT_FALSE(client.connected());
 }
 
+// Mongoose 7 sends mg_mqtt_opts.keepalive to the broker verbatim, and 0 means
+// "no timeout" (unlike 6.18, which substituted 60 for a 0). Without a
+// non-zero default, LWT would never fire on an ungraceful disconnect.
+static void test_mqtt_keepalive_defaults_to_60_and_is_settable() {
+  MongooseMqttClient client;
+
+  TEST_ASSERT_EQUAL(60, client.keepAlive());
+
+  client.setKeepAlive(30);
+  TEST_ASSERT_EQUAL(30, client.keepAlive());
+
+  // 0 stays available for callers who explicitly want no timeout.
+  client.setKeepAlive(0);
+  TEST_ASSERT_EQUAL(0, client.keepAlive());
+}
+
 static void test_mqtt_connack_code_tracks_broker_rejection() {
   ScopedMongoose mongoose;
   TestableMqttClient client;
@@ -204,6 +220,7 @@ static void test_mqtt_subscribe_with_qos_and_disconnect_handler() {
 
 void runMqttClientTests() {
   RUN_TEST(test_mqtt_api_setters_compile_and_do_not_crash);
+  RUN_TEST(test_mqtt_keepalive_defaults_to_60_and_is_settable);
   RUN_TEST(test_mqtt_connack_code_tracks_broker_rejection);
   RUN_TEST(test_mqtt_round_trip_with_local_broker);
   RUN_TEST(test_mqtt_subscribe_with_qos_and_disconnect_handler);


### PR DESCRIPTION
## Summary
This PR adds support for configuring the MQTT CONNECT keepalive interval in the MongooseMqttClient, with a default value of 60 seconds to ensure Last Will Testament (LWT) messages are properly delivered on ungraceful disconnects.

## Key Changes
- Added `_keepalive` member variable to `MongooseMqttClient` class, initialized to 60 seconds by default
- Added `setKeepAlive(uint16_t seconds)` method to allow callers to configure the keepalive interval
- Added `keepAlive()` const getter method to retrieve the current keepalive value
- Updated MQTT connection logic to pass the keepalive value to the broker via `mg_mqtt_opts.keepalive`
- Added comprehensive unit test verifying default value of 60s and that the setter/getter work correctly, including support for explicitly setting 0 to disable keepalive

## Implementation Details
- The keepalive value is now sent verbatim to the broker (Mongoose 7 behavior), unlike Mongoose 6.18 which silently substituted 60 for a 0
- Default of 60 seconds ensures the broker detects ungraceful disconnects (power loss, WiFi drop) and fires the Last Will Testament
- Callers can explicitly pass 0 to opt into "no timeout" behavior if desired
- Also includes documentation clarification in `MongooseHttpServerRequest.h` about HTTP message body lifetime and buffer management

https://claude.ai/code/session_01LcQ1TxJJhKPvczHxjaz7b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - MQTT connections now use a configurable keepalive interval.
  - The default keepalive interval is 60 seconds.
  - Applications can change the interval or set it to zero to disable the timeout.

- **Documentation**
  - Clarified request body lifetime and buffer usage.

- **Tests**
  - Added coverage for default, custom, and disabled keepalive settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->