### PR TITLE
feat: expose the resolved peer address on the MQTT and SNTP clients

### DIFF
--- a/src/MongooseCore.cpp
+++ b/src/MongooseCore.cpp
@@ -25,6 +25,44 @@ MongooseCore::MongooseCore() :
 {
 }
 
+bool mongooseRemoteAddress(struct mg_connection *nc, char *buf, size_t len)
+{
+  if(NULL == buf || len < 1) {
+    return false;
+  }
+  buf[0] = '\0';
+
+  if(NULL == nc) {
+    return false;
+  }
+
+  /*
+   * mg_parse_address() zeroes the address and sets AF_INET before any
+   * resolution happens, so an all-zero address means "no peer yet" rather
+   * than a genuine 0.0.0.0.
+   */
+  const unsigned char *addr;
+  size_t addr_len;
+#if MG_ENABLE_IPV6
+  if(AF_INET6 == nc->sa.sa.sa_family) {
+    addr = (const unsigned char *) &nc->sa.sin6.sin6_addr;
+    addr_len = sizeof(nc->sa.sin6.sin6_addr);
+  } else
+#endif
+  {
+    addr = (const unsigned char *) &nc->sa.sin.sin_addr;
+    addr_len = sizeof(nc->sa.sin.sin_addr);
+  }
+
+  while(addr_len-- > 0) {
+    if(0 != addr[addr_len]) {
+      return mg_sock_addr_to_str(&nc->sa, buf, len, MG_SOCK_STRINGIFY_IP) > 0;
+    }
+  }
+
+  return false;
+}
+
 void MongooseCore::begin() 
 {
   mg_mgr_init(&mgr, this);

--- a/src/MongooseCore.h
+++ b/src/MongooseCore.h
@@ -16,6 +16,26 @@
 
 typedef std::function<const char *(void)> ArduinoMongooseGetRootCaCallback;
 
+// Enough for the longest IPv6 text form plus its terminator
+#define MONGOOSE_ADDRESS_LEN 46
+
+/*
+ * Format the address a connection's peer was resolved to, into buf.
+ *
+ * Mongoose resolves the peer asynchronously and stores the answer on the
+ * connection, so this needs no DNS query of its own -- which matters because
+ * the synchronous resolvers block, and on a single-threaded application task
+ * under a watchdog that is a reboot rather than a delay.
+ *
+ * Reads nc->sa rather than going through mg_conn_addr_to_str(), which asks the
+ * socket layer for the peer and so answers only once the socket is connected;
+ * nc->sa holds the address as soon as resolution completes.
+ *
+ * Writes an empty string and returns false when there is no resolved peer:
+ * no connection, resolution still in flight, or resolution failed.
+ */
+bool mongooseRemoteAddress(struct mg_connection *nc, char *buf, size_t len);
+
 class MongooseCore
 {
   private:

--- a/src/MongooseMqttClient.cpp
+++ b/src/MongooseMqttClient.cpp
@@ -28,7 +28,7 @@ MongooseMqttClient::MongooseMqttClient() :
   _onError(NULL),
   _onClose(NULL)
 {
-
+  _remoteAddress[0] = '\0';
 }
 
 MongooseMqttClient::~MongooseMqttClient()
@@ -46,7 +46,12 @@ void MongooseMqttClient::eventHandler(struct mg_connection *nc, int ev, void *p)
 {
   struct mg_mqtt_message *msg = (struct mg_mqtt_message *) p;
 
-  if (ev != MG_EV_POLL) { DBUGF("%s %p: %d", __PRETTY_FUNCTION__, nc, ev); }
+  if (ev != MG_EV_POLL) {
+    DBUGF("%s %p: %d", __PRETTY_FUNCTION__, nc, ev);
+    // Keep the resolved broker address current while we still have the
+    // connection; the peer can differ between reconnects.
+    mongooseRemoteAddress(nc, _remoteAddress, sizeof(_remoteAddress));
+  }
 
   switch (ev) 
   {

--- a/src/MongooseMqttClient.h
+++ b/src/MongooseMqttClient.h
@@ -9,6 +9,7 @@
 
 #include <functional>
 
+#include "MongooseCore.h"
 #include "MongooseString.h"
 
 class MongooseMqttClient;
@@ -39,6 +40,7 @@ class MongooseMqttClient
     struct mg_connection *_nc;
     bool _connected;
     bool _reject_unauthorized; 
+    char _remoteAddress[MONGOOSE_ADDRESS_LEN];
 
     MongooseMqttConnectionHandler _onConnect;
     MongooseMqttMessageHandler _onMessage;
@@ -97,6 +99,15 @@ class MongooseMqttClient
 
   bool connected() {
     return _nc &&  _connected;
+  }
+
+  /*
+   * The address the broker was resolved to, or "" if that is not known yet.
+   * Recorded as events arrive, so it stays readable from a handler after the
+   * connection has gone.
+   */
+  const char *remoteAddress() {
+    return _remoteAddress;
   }
 
   void onMessage(MongooseMqttMessageHandler fnHandler) {

--- a/src/MongooseSntpClient.cpp
+++ b/src/MongooseSntpClient.cpp
@@ -18,7 +18,7 @@ MongooseSntpClient::MongooseSntpClient() :
   _onTime(NULL),
   _onError(NULL)
 {
-
+  _remoteAddress[0] = '\0';
 }
 
 MongooseSntpClient::~MongooseSntpClient()
@@ -36,7 +36,12 @@ void MongooseSntpClient::eventHandler(struct mg_connection *nc, int ev, void *p)
 {
   struct mg_sntp_message *msg = (struct mg_sntp_message *) p;
 
-  if (ev != MG_EV_POLL) { DBUGF("%s %p: %d", __PRETTY_FUNCTION__, nc, ev); }
+  if (ev != MG_EV_POLL) {
+    DBUGF("%s %p: %d", __PRETTY_FUNCTION__, nc, ev);
+    // Keep the resolved server address current while we still have the
+    // connection; a pool hostname resolves to a different peer each time.
+    mongooseRemoteAddress(nc, _remoteAddress, sizeof(_remoteAddress));
+  }
 
   switch (ev) 
   {

--- a/src/MongooseSntpClient.h
+++ b/src/MongooseSntpClient.h
@@ -11,6 +11,7 @@
 
 #include <functional>
 
+#include "MongooseCore.h"
 #include "MongooseString.h"
 
 class MongooseSntpClient;
@@ -25,6 +26,7 @@ class MongooseSntpClient
 
     MongooseSntpTimeHandler _onTime;
     MongooseSntpErrorHandler _onError;
+    char _remoteAddress[MONGOOSE_ADDRESS_LEN];
 
   protected:
     static void eventHandler(struct mg_connection *nc, int ev, void *p, void *u);
@@ -44,6 +46,16 @@ class MongooseSntpClient
 
   void onError(MongooseSntpErrorHandler fnHandler) {
     _onError = fnHandler;
+  }
+
+  /*
+   * The address the server was resolved to, or "" if that is not known yet.
+   * Recorded as events arrive, so an onError() handler can tell a name that
+   * did not resolve from a server that did not answer -- without resolving
+   * the name a second time.
+   */
+  const char *remoteAddress() {
+    return _remoteAddress;
   }
 };
 


### PR DESCRIPTION
## The problem

Mongoose resolves a connection's peer asynchronously and stores the answer on the connection, but neither client lets a consumer read it. So code that wants to show "which address are we actually talking to" has to resolve the hostname a second time with `getaddrinfo()`.

That is worse than it sounds:

- The synchronous resolvers block for the whole query. On a single-threaded application task under a watchdog, a slow or failing lookup is a **reboot**, not a delay. With `LWIP_IPV6` an `AF_UNSPEC` lookup asks for A and AAAA, each up to `DNS_MAX_RETRIES` times against every configured server.
- It is less accurate. A second lookup of a pool hostname can return a different server than the one that answered.
- On an error path it cannot answer the question being asked. Resolving the name again cannot distinguish "this name does not resolve" from "it resolved, but the peer refused the connection" — and that is exactly what an error handler wants to know.

This came out of a real watchdog panic: `loopTask (CPU 1)` starved, with `lwip_netconn_do_gethostbyname` and `dns_timeout_cb` on the stack beneath `MongooseSntpClient::eventHandler`. The consumer's own error handler was resolving a name that had just failed to resolve.

## The change

`MongooseMqttClient::remoteAddress()` and `MongooseSntpClient::remoteAddress()`, each returning the peer address as text, or `""` when there is no resolved peer.

Both record it from the connection as events arrive rather than reading it on demand, because the address is most wanted on the paths where the connection has just gone — a close, or the `MG_EV_CONNECT` failure that a DNS failure produces before `MG_EV_CLOSE` and `mg_destroy_conn()`. Both clients already null `_nc` in their `MG_EV_CLOSE` handler, so recording keeps the value readable and avoids any question of a stale pointer.

Shared formatting lives in `mongooseRemoteAddress()` in `MongooseCore`. Two details worth flagging for review:

- It reads `nc->sa` rather than going through `mg_conn_addr_to_str(..., MG_SOCK_STRINGIFY_REMOTE)`. That helper asks the socket layer for the peer via `mg_if_get_conn_addr()`, so it only answers once the socket is connected; `nc->sa` holds the address as soon as `resolve_cb()` writes it.
- `mg_parse_address()` does `memset(sa, 0, ...)` and then sets `sin_family = AF_INET` before any resolution happens, so the family tells you nothing about whether an address is present. The check is on the address bytes being non-zero — otherwise an unresolved connection reports a plausible-looking `0.0.0.0`.

Costs `MONGOOSE_ADDRESS_LEN` (46) bytes per client, and no meaningful flash.

## Testing

There is no test harness on this branch, so this was exercised through its consumer: the OpenEVSE ESP32 firmware, where it replaces both blocking lookups. That build is clean on `openevse_wifi_v1` and on the EpoxyDuino host target, and the change **removes 287 lines and adds 50** there — the deferred-lookup flag, two `dns_gethostbyname()` calls and their TCP/IP-thread callbacks, a release/acquire handoff, a collection poll with a lost-callback deadline, and the host/target `#ifdef` divergence all go away.

The equivalent change for `mongoose_7` is filed separately, and does carry unit tests (`tests/unit` exists on that branch): jeremypoulter/ArduinoMongoose#103. The `mongoose_7` version also fixes a null dereference in the existing `getRemoteAddress()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added access to the resolved remote address for MQTT broker connections.
  - Added access to the resolved remote address for SNTP server connections.
  - Remote addresses remain available after disconnection and are refreshed when connections are re-established.
  - Address values are returned in readable IPv4 or IPv6 format.
  - The address is empty until a remote peer has been resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->