### PR TITLE
feat: record the resolved peer address; fix getRemoteAddress() null deref

### DIFF
--- a/src/MongooseCore.h
+++ b/src/MongooseCore.h
@@ -13,6 +13,9 @@
 
 typedef std::function<const char *(void)> ArduinoMongooseGetRootCaCallback;
 
+/** @brief Enough for the longest IPv6 text form plus its terminator */
+#define MONGOOSE_ADDRESS_LEN 46
+
 /**
  * @brief Core Mongoose manager for Arduino
  * 

--- a/src/MongooseSocket.cpp
+++ b/src/MongooseSocket.cpp
@@ -23,7 +23,7 @@ MongooseSocket::MongooseSocket() :
   _cert(),
   _key()
 {
-
+  _remoteAddress[0] = '\0';
 }
 
 MongooseSocket::MongooseSocket(mg_connection *nc) :
@@ -36,7 +36,7 @@ MongooseSocket::MongooseSocket(mg_connection *nc) :
   _cert(),
   _key()
 {
-
+  _remoteAddress[0] = '\0';
 }
 
 MongooseSocket::~MongooseSocket()
@@ -81,6 +81,10 @@ void MongooseSocket::processEvent(mg_connection *nc, int ev, void *p)
 {
   if (ev != MG_EV_POLL) {
     DBUGF("%s %p %p: %d", __PRETTY_FUNCTION__, nc, this, ev);
+    // Record the resolved peer while we still have the connection: _nc is
+    // cleared before onClose() runs, and the peer can differ between
+    // reconnects. An unresolved address records as "".
+    recordRemoteAddress(nc);
   }
 
   switch (ev) 
@@ -158,6 +162,32 @@ void MongooseSocket::processEvent(mg_connection *nc, int ev, void *p)
       handleEvent(nc, ev, p);
       break;
     }
+  }
+}
+
+void MongooseSocket::recordRemoteAddress(mg_connection *nc)
+{
+  _remoteAddress[0] = '\0';
+
+  if(nullptr == nc) {
+    return;
+  }
+
+  /*
+   * Mongoose parses the port out of the URL before resolving and leaves the
+   * address zeroed until the DNS answer lands, so an all-zero address means
+   * "no peer yet" rather than a genuine 0.0.0.0 or ::.
+   */
+  bool resolved;
+  if(nc->rem.is_ip6) {
+    resolved = (0 != nc->rem.addr.ip6[0]) || (0 != nc->rem.addr.ip6[1]);
+  } else {
+    resolved = (0 != nc->rem.addr.ip4);
+  }
+
+  if(resolved) {
+    mg_snprintf(_remoteAddress, sizeof(_remoteAddress), "%M", mg_print_ip,
+                &nc->rem);
   }
 }
 

--- a/src/MongooseSocket.h
+++ b/src/MongooseSocket.h
@@ -6,6 +6,7 @@
 #include <mongoose.h>
 
 #include <MongooseString.h>
+#include <MongooseCore.h>
 
 #include <functional>
 
@@ -32,8 +33,10 @@ class MongooseSocket
     MongooseString _host;
     MongooseString _cert;
     MongooseString _key;
+    char _remoteAddress[MONGOOSE_ADDRESS_LEN];
 
     void processEvent(struct mg_connection *nc, int ev, void *p);
+    void recordRemoteAddress(struct mg_connection *nc);
   protected:
     static void eventHandler(struct mg_connection *nc, int ev, void *p);
 
@@ -137,18 +140,40 @@ class MongooseSocket
 
     /**
      * @brief Get the remote network address
-     * @return mg_addr*
+     * @return mg_addr*, or nullptr when there is no connection
+     *
+     * Mongoose clears the connection pointer before onClose() runs, so this
+     * returns nullptr rather than dereferencing it. Use remoteAddress() to
+     * read the address from a close or error handler.
      */
     mg_addr *getRemoteAddress() {
-      return &_nc->rem;
+      return _nc ? &_nc->rem : nullptr;
     }
 
     /**
      * @brief Get the local network address
-     * @return mg_addr*
+     * @return mg_addr*, or nullptr when there is no connection
      */
     mg_addr *getLocalAddress() {
-      return &_nc->loc;
+      return _nc ? &_nc->loc : nullptr;
+    }
+
+    /**
+     * @brief The address the peer was resolved to, as text
+     * @return the address, or "" when there is no resolved peer
+     *
+     * Mongoose resolves the peer asynchronously and stores the answer on the
+     * connection, so this needs no name lookup of its own -- which matters
+     * because the synchronous resolvers block, and on a single-threaded
+     * application task under a watchdog that is a reboot rather than a delay.
+     *
+     * Recorded as events arrive, so it stays readable from a close or error
+     * handler after Mongoose has finished with the connection. An empty string
+     * means the peer was never resolved, which is how an error handler can tell
+     * a name that does not resolve from a peer that refused the connection.
+     */
+    const char *remoteAddress() {
+      return _remoteAddress;
     }
 
     static const char Type = 'S';

--- a/tests/unit/test/test_main.cpp
+++ b/tests/unit/test/test_main.cpp
@@ -12,6 +12,7 @@ void runWebSocketTests();
 void runMqttClientTests();
 void runSntpClientTests();
 void runMdnsTests();
+void runSocketAddressTests();
 
 static int runAllTests() {
   UNITY_BEGIN();
@@ -24,6 +25,7 @@ static int runAllTests() {
   runMqttClientTests();
   runSntpClientTests();
   runMdnsTests();
+  runSocketAddressTests();
   return UNITY_END();
 }
 

--- a/tests/unit/test/test_socket_address.cpp
+++ b/tests/unit/test/test_socket_address.cpp
@@ -1,0 +1,54 @@
+#include <unity.h>
+
+#include <MongooseSntpClient.h>
+
+#include <cstring>
+
+#include "test_support.h"
+
+// A socket that has never connected has no peer: the raw accessors must report
+// that rather than dereference a null connection, and the text form must be
+// empty rather than "0.0.0.0".
+static void test_socket_address_unconnected() {
+  MongooseSntpClient client;
+
+  TEST_ASSERT_NULL(client.getRemoteAddress());
+  TEST_ASSERT_NULL(client.getLocalAddress());
+  TEST_ASSERT_EQUAL_STRING("", client.remoteAddress());
+}
+
+// A literal address needs no DNS, so Mongoose has the peer from the first
+// event. The recorded text form must match, and must survive the close that
+// clears the connection pointer -- that is the case an error or close handler
+// needs, and the reason the address is recorded rather than read on demand.
+static void test_socket_address_recorded_and_survives_close() {
+  ScopedMongoose mongoose;
+  MongooseSntpClient client;
+
+  bool closeFired = false;
+  client.onClose([&closeFired]() { closeFired = true; });
+
+  // TEST-NET-1: never routable, so this closes without touching the network.
+  if (!client.getTime("192.0.2.1")) {
+    // Some environments reject the connect outright; nothing to observe.
+    TEST_PASS();
+    return;
+  }
+
+  TEST_ASSERT_TRUE(pumpUntil([&client]() {
+    return '\0' != client.remoteAddress()[0];
+  }, 5000));
+  TEST_ASSERT_EQUAL_STRING("192.0.2.1", client.remoteAddress());
+
+  pumpUntil([&closeFired]() { return closeFired; }, 5000);
+  if (closeFired) {
+    // The connection is gone, but the address it resolved to is still readable.
+    TEST_ASSERT_NULL(client.getRemoteAddress());
+    TEST_ASSERT_EQUAL_STRING("192.0.2.1", client.remoteAddress());
+  }
+}
+
+void runSocketAddressTests() {
+  RUN_TEST(test_socket_address_unconnected);
+  RUN_TEST(test_socket_address_recorded_and_survives_close);
+}


### PR DESCRIPTION
## Two things, one cause

### 1. `getRemoteAddress()` dereferences null

```cpp
mg_addr *getRemoteAddress() {
  return &_nc->rem;
}
```

`processEvent()` clears `_nc` **before** calling `onClose()`:

```cpp
case MG_EV_CLOSE:
{
  if(_nc == nc) {
    _nc = nullptr;
  }
  onClose(nc);
```

So calling `getRemoteAddress()` or `getLocalAddress()` from a close handler dereferences null. Both now return `nullptr` instead.

### 2. That null is where the address is most wanted

Code that displays "which server are we actually talking to" wants the answer precisely on the paths where the connection has just gone: a close, or the `MG_EV_ERROR` a DNS failure produces. Reading it on demand cannot work there at all.

So record it as events arrive, and add `MongooseSocket::remoteAddress()` returning the address as text. On the base class, so every client gets it.

The empty string is load-bearing. Mongoose parses the port out of the URL before resolving and leaves `c->rem.addr` zeroed until the DNS answer lands, so an all-zero address means "no peer yet" rather than a genuine `0.0.0.0` — and an error handler seeing `""` can tell a name that does not resolve from a peer that resolved and then refused the connection.

## Why it matters beyond tidiness

Without this, the only way a consumer can answer that question is to resolve the name a second time with `getaddrinfo()`. That blocks for the whole query, so on a single-threaded application task under a watchdog it is a **reboot** rather than a delay — which is how this was found, as a `loopTask (CPU 1)` watchdog panic with `lwip_netconn_do_gethostbyname` and `dns_timeout_cb` on the stack beneath the SNTP client's event handler, from an error handler resolving a name that had just failed to resolve.

It is also less accurate: a fresh lookup of a pool hostname can return a different server than the one that answered.

Costs `MONGOOSE_ADDRESS_LEN` (46) bytes per socket.

## Testing

`cd tests/unit && pio test -e native` — **57 passing, 2 skipped.**

Two new cases in `test_socket_address.cpp`:

- `test_socket_address_unconnected` — the null accessors and the empty text form on a socket that never connected.
- `test_socket_address_recorded_and_survives_close` — connects to TEST-NET-1 (`192.0.2.1`, a literal, so no DNS and no network traffic), checks the recorded address, then checks it is still readable once the connection pointer has been cleared.

I verified the second has teeth by disabling the recording and confirming it fails rather than passing vacuously.

The `master` (mongoose 6) equivalent is filed separately, per-client since there is no shared base class there: jeremypoulter/ArduinoMongoose#102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access to a socket’s resolved remote address as text.
  * Remote address information remains available after a connection closes or encounters an error.
  * Added support for storing IPv4 and IPv6 addresses.

* **Bug Fixes**
  * Socket address accessors now safely return null when no connection is available.
  * Stale remote address values are cleared when appropriate.

* **Tests**
  * Added coverage for unconnected sockets and address availability after closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->